### PR TITLE
Fix missing colon in sed call_control replace.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -141,7 +141,7 @@ case "$1" in
         # update jitsi-meet config
         JITSI_MEET_CONFIG="/etc/jitsi/meet/$JVB_HOSTNAME-config.js"
         if [ ! "$(grep "call_control: 'callcontrol.$JVB_HOSTNAME'" $JITSI_MEET_CONFIG)" ] || [ "$(grep "//call_control: 'callcontrol.$JVB_HOSTNAME'" $JITSI_MEET_CONFIG)" ]; then
-            JIGASI_MEET="        call_control: 'callcontrol.$JVB_HOSTNAME'"
+            JIGASI_MEET="        call_control: 'callcontrol.$JVB_HOSTNAME',"
             #sed -i "s/hosts:\ {/hosts:\ {\n\t$JIGASI_MEET/g" /usr/share/jitsi-meet/config.js
             sed -i "s/.*call_control: .*/$JIGASI_MEET/" $JITSI_MEET_CONFIG
         fi


### PR DESCRIPTION
During postinstall jigasi replaces the call control value in the jitsi-meet config. But depending on the jitsi-meet config it may break the JSON format, due to the missing colon and the end o f the line.