### PR TITLE
Add $JIGASI_OPTS variable to the init.d and config files.

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -37,7 +37,7 @@ DESC=jigasi
 if [ ! $JVB_HOST ]; then
     JVB_HOST=localhost
 fi
-DAEMON_OPTS=" --host=$JVB_HOST --domain=$JVB_HOSTNAME --subdomain=callcontrol --secret=$JIGASI_SECRET --logdir=$LOGDIR --configdir=/etc/jitsi --configdirname=jigasi"
+DAEMON_OPTS=" --host=$JVB_HOST --domain=$JVB_HOSTNAME --subdomain=callcontrol --secret=$JIGASI_SECRET --logdir=$LOGDIR --configdir=/etc/jitsi --configdirname=jigasi $JIGASI_OPTS"
 
 test -x $DAEMON || exit 0
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -70,6 +70,7 @@ case "$1" in
             echo "JIGASI_SIPUSER=$JIGASI_SIPUSER" >> $CONFIG
             echo "JIGASI_SIPPWD=$JIGASI_SIPPWD" >> $CONFIG
             echo "JIGASI_SECRET=$JIGASI_SECRET" >> $CONFIG
+            echo "JIGASI_OPTS=\"\"" >> $CONFIG
         fi
 
         # let's check whether there is a setting in the $CONFIG


### PR DESCRIPTION
Just like the videobridge, allow the user to specify additional configuration options to jigasi. For example specify a different port range.