### PR TITLE
net.java.sip.communicator.service.gui.ALWAYS_TRUST_MODE_ENABLED is se…

### DIFF
--- a/jigasi-home/sip-communicator.properties
+++ b/jigasi-home/sip-communicator.properties
@@ -61,3 +61,8 @@ org.jitsi.jigasi.xmpp.acc.SERVER_ADDRESS=127.0.0.1
 # If you want to use the SIP user part of the incoming/outgoing call SIP URI
 # you can set the following property to true.
 # org.jitsi.jigasi.USE_SIP_USER_AS_XMPP_RESOURCE=true
+
+# Activate this property if you are using self-signed certificates or other
+# type of non-trusted certicates. In this mode your service trust in the 
+# remote certificates always.
+# net.java.sip.communicator.service.gui.ALWAYS_TRUST_MODE_ENABLED=true

--- a/src/main/java/org/jitsi/jigasi/Main.java
+++ b/src/main/java/org/jitsi/jigasi/Main.java
@@ -216,12 +216,6 @@ public class Main
             ConfigurationService.PNAME_SC_HOME_DIR_NAME,
             configDirName);
 
-        // FIXME: Always trust mode - prevent failures because there's no GUI
-        // to ask the user, but do we always want to trust ?
-        System.setProperty(
-            "net.java.sip.communicator.service.gui.ALWAYS_TRUST_MODE_ENABLED",
-            "true");
-
         String logdir = cmdLine.getOptionValue(LOGDIR_ARG_NAME);
         if (!StringUtils.isNullOrEmpty(logdir))
         {

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControlComponent.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControlComponent.java
@@ -122,6 +122,16 @@ public class CallControlComponent
         ConfigurationService config
             = ServiceUtils.getService(
                     bundleContext, ConfigurationService.class);
+        
+        Boolean always_trust_mode = config.getBoolean(
+                "net.java.sip.communicator.service.gui.ALWAYS_TRUST_MODE_ENABLED",false);
+        if (always_trust_mode)
+        {
+                // Always trust mode - prevent failures because there's no GUI
+                // to ask the user, but do we always want to trust so, in this
+                // mode, the service is vulnerable to Man-In-The-Middle attacks.
+                logger.warn("Always trust in remote TLS certificates mode is enabled");
+        }
 
         this.allowedJid = config.getString(ALLOWED_JID_P_NAME, null);
 


### PR DESCRIPTION
net.java.sip.communicator.service.gui.ALWAYS_TRUST_MODE_ENABLED is set in sip-communicator.properties

I could suggest this trivial change in the jigasi code as consequence of the topic discussed on this thread: http://lists.jitsi.org/pipermail/users/2016-June/011191.html (http://lists.jitsi.org/pipermail/users/2016-June/thread.html#11191)

The reason: move the configuration of  the ALWAYS_TRUST_MODE_ENABLED property to the sip-communicator.properties, so as sysadmin you can take the decision of trust or not in all the certificates. By default, I considered the ALWAYS_TRUST_MODE_ENABLED=false as a more secure option in order to prevent MiM attacks.