### PR TITLE
Fix SDP origin Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ It is possible to install Jigasi along with Jitsi Meet using our [quick install 
 
 1. Install required dependencies, per OS.  On Ubuntu:
 
-```
-apt-get install openjdk-7-jdk ant-contrib ant-task libmaven-ant-tasks-java
-```
+ ```
+ apt-get install openjdk-7-jdk ant-contrib ant-task libmaven-ant-tasks-java
+ ```
 
 2. Checkout latest source:
  

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It is possible to install Jigasi along with Jitsi Meet using our [quick install 
 
  ```
  cd jigasi
+ ant deb-copy-jigasi
  ant make
  ```
  

--- a/README.md
+++ b/README.md
@@ -10,29 +10,35 @@ It is possible to install Jigasi along with Jitsi Meet using our [quick install 
 
 [quick install instructions]: https://github.com/turint/jitsi-meet/blob/master/doc/quick-install.md
 
-1. Checkout latest source:
+1. Install required dependencies, per OS.  On Ubuntu:
+
+```
+apt-get install openjdk-7-jdk ant-contrib ant-task libmaven-ant-tasks-java
+```
+
+2. Checkout latest source:
  
  ```
  git clone https://github.com/jitsi/jigasi.git
  ```
-2. Build:
+3. Build:
 
  ```
  cd jigasi
  ant make
  ```
  
-3. Configure external component in your XMPP server. If your server is Prosody: edit /etc/prosody/prosody.cfg.lua and append following lines to your config (assuming that subdomain is 'callcontrol' and domain 'meet.jit.si'):
+4. Configure external component in your XMPP server. If your server is Prosody: edit /etc/prosody/prosody.cfg.lua and append following lines to your config (assuming that subdomain is 'callcontrol' and domain 'meet.jit.si'):
 
  ```
  Component "callcontrol.meet.jit.si"
      component_secret = "topsecret"
  ```
-4. Setup SIP account
+5. Setup SIP account
 
  Go to jigasi/jigasi-home and edit sip-communicator.properties file. Replace ```<<JIGASI_SIPUSER>>``` tag with SIP username for example: "user1232@sipserver.net". Then put Base64 encoded password in place of ```<<JIGASI_SIPPWD>>```.
 
-5. Start Jigasi
+6. Start Jigasi
  
  ```
  ./jigasi.sh --domain=meet.jit.si --subdomain=callcontrol --secret=topsecret

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
     <dependency>
       <groupId>org.opentelecoms.sdp</groupId>
       <artifactId>java-sdp-nist-bridge</artifactId>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.jitsi</groupId>


### PR DESCRIPTION
This resolves an issue with PJSIP compatibility where the origin header on outbound SIP invites was invalid per RFC.  This resolves the issue.

Also added a couple minor Readme notes to assist people just building this for the first time.
