### PR TITLE
refactor of GatewaySession and SipGateway

### DIFF
--- a/src/main/java/org/jitsi/jigasi/AbstractGateway.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGateway.java
@@ -32,6 +32,7 @@ import java.util.*;
  * information retrieved from jvb conference which is joined
  *
  * @author Pawel Domas
+ * @author Nik Vaessen
  */
 public abstract class AbstractGateway<T extends AbstractGatewaySession>
     implements RegistrationStateChangeListener,
@@ -40,8 +41,8 @@ public abstract class AbstractGateway<T extends AbstractGatewaySession>
     /**
      * The logger
      */
-    private final static Logger logger = Logger.getLogger(AbstractGateway.
-                                                              class);
+    private final static Logger logger
+        = Logger.getLogger(AbstractGateway.class);
 
     /**
      * Name of the property used to override incoming
@@ -71,8 +72,7 @@ public abstract class AbstractGateway<T extends AbstractGatewaySession>
     /**
      * A map which matches CallContext to the specific session of a Gateway.
      */
-    private final Map<CallContext, T> sessions =
-        new HashMap<>();
+    private final Map<CallContext, T> sessions = new HashMap<>();
 
     /**
      * Indicates if jigasi instance has entered graceful shutdown mode.

--- a/src/main/java/org/jitsi/jigasi/AbstractGateway.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGateway.java
@@ -1,0 +1,348 @@
+/*
+ * Jigasi, the JItsi GAteway to SIP.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jigasi;
+
+import net.java.sip.communicator.service.protocol.*;
+import net.java.sip.communicator.service.protocol.event.*;
+import net.java.sip.communicator.service.shutdown.*;
+import net.java.sip.communicator.util.*;
+import org.osgi.framework.*;
+
+import java.util.*;
+
+/**
+ * An abstract Gateway which can join an jvb conference with an xmpp account
+ *
+ * Manages {@link AbstractGatewaySession}'s which will do something with
+ * information retrieved from jvb conference which is joined
+ *
+ * @author Pawel Domas
+ */
+public abstract class AbstractGateway<T extends AbstractGatewaySession>
+    implements RegistrationStateChangeListener,
+               GatewaySessionListener<T>
+{
+    /**
+     * The logger
+     */
+    private final static Logger logger = Logger.getLogger(AbstractGateway.
+                                                              class);
+
+    /**
+     * Name of the property used to override incoming
+     */
+    public static final String P_NAME_DEFAULT_JVB_ROOM
+        = "org.jitsi.jigasi.DEFAULT_JVB_ROOM_NAME";
+
+    /**
+     * Name of the property used to set default JVB conference invite timeout.
+     */
+    public static final String P_NAME_JVB_INVITE_TIMEOUT
+        = "org.jitsi.jigasi.JVB_INVITE_TIMEOUT";
+
+    /**
+     * Name of the property used to disable advertisement of ICE feature in
+     * XMPP capabilities list. This allows conference manager to allocate
+     * channels with RAW transport and speed up connectivity process.
+     */
+    public static final String P_NAME_DISABLE_ICE
+        = "org.jitsi.jigasi.DISABLE_ICE";
+
+    /**
+     * Default JVB conference invite timeout.
+     */
+    public static final long DEFAULT_JVB_INVITE_TIMEOUT = 30L * 1000L;
+
+    /**
+     * A map which matches CallContext to the specific session of a Gateway.
+     */
+    private final Map<CallContext, T> sessions =
+        new HashMap<>();
+
+    /**
+     * Indicates if jigasi instance has entered graceful shutdown mode.
+     */
+    private boolean shutdownInProgress;
+
+    /**
+     * The (OSGi) <tt>BundleContext</tt> in which this <tt>AbstractGateway</tt>
+     * has been started.
+     */
+    private BundleContext bundleContext;
+
+    /**
+     * Listeners that will be notified of changes in a Gateway.
+     */
+    private final ArrayList<GatewayListener> gatewayListeners
+        = new ArrayList<>();
+
+    /**
+     * Creates new instance of an <tt>AbstractGateway</tt>.
+     */
+    public AbstractGateway(BundleContext bundleContext)
+    {
+        this.bundleContext = bundleContext;
+    }
+
+    /**
+     * This method should handle stopping this gateway.
+     */
+    public abstract void stop();
+
+    @Override
+    public void registrationStateChanged(RegistrationStateChangeEvent evt)
+    {
+        ProtocolProviderService pps = evt.getProvider();
+
+        logger.info("REG STATE CHANGE " + pps + " -> " + evt);
+    }
+
+    /**
+     * Notified that current call has ended.
+     *
+     * @param callContext the context of the call ended.
+     */
+    void notifyCallEnded(CallContext callContext)
+    {
+        T session;
+
+        synchronized (sessions)
+        {
+            session = sessions.remove(callContext);
+
+            if (session == null)
+            {
+                // FIXME: print some gateway ID or provider here
+                logger.error(
+                    "Call resource not exists for session "
+                    + callContext.getCallResource());
+                return;
+            }
+
+            fireGatewaySessionRemoved(session);
+        }
+
+        logger.info("Removed session for call "
+                    + callContext.getCallResource());
+
+        // Check if it's the time to shutdown now
+        maybeDoShutdown();
+    }
+
+    /**
+     * This method should starts a new outgoing session which should join a JVB
+     * conference held in given MUC room.
+     *
+     * @param ctx the call context for which to create a call
+
+     * @return the newly created GatewaySession.
+     */
+    public abstract T createOutgoingCall(CallContext ctx);
+
+    /**
+     * When a room is joined for incoming/outgoing calls we store the session
+     * based on its call context and fire event that session had been added.
+     *
+     * @param source the {@link AbstractGatewaySession} on which the event takes
+     *               place.
+     */
+    @Override
+    public void onJvbRoomJoined(T source)
+    {
+        sessions.put(source.getCallContext(), source);
+
+        fireGatewaySessionAdded(source);
+    }
+
+    /**
+     * Finds {@link AbstractGatewaySession} for given <tt>callResource</tt> if
+     * one is currently active.
+     *
+     * @param callResource the call resource/URI of the
+     *                     <tt>AbstractGatewaySession</tt> to be found.
+     *
+     * @return {@link AbstractGatewaySession} for given <tt>callResource</tt> if
+     * there is one currently active or <tt>null</tt> otherwise.
+     */
+    public T getSession(String callResource)
+    {
+        synchronized (sessions)
+        {
+            for (Map.Entry<CallContext, T> en
+                : sessions.entrySet())
+            {
+                if (callResource.equals(en.getKey().getCallResource()))
+                    return en.getValue();
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * @return the list of <tt>AbstractGatewaySession</tt>s currently active.
+     */
+    public List<T> getActiveSessions()
+    {
+        synchronized (sessions)
+        {
+            return new ArrayList<>(sessions.values());
+        }
+    }
+
+    /**
+     * Returns timeout for waiting for the JVB conference invite from the focus.
+     */
+    public static long getJvbInviteTimeout()
+    {
+        return JigasiBundleActivator.getConfigurationService()
+                                    .getLong(P_NAME_JVB_INVITE_TIMEOUT,
+                                             DEFAULT_JVB_INVITE_TIMEOUT);
+    }
+
+    /**
+     * Sets new timeout for waiting for the JVB conference invite from the
+     * focus.
+     * @param newTimeout the new timeout value in ms to set.
+     */
+    public static void setJvbInviteTimeout(long newTimeout)
+    {
+        JigasiBundleActivator.getConfigurationService()
+                             .setProperty(
+                                     AbstractGateway.P_NAME_JVB_INVITE_TIMEOUT,
+                                          newTimeout);
+    }
+
+    /**
+     * Enables graceful shutdown mode on this jigasi instance and eventually
+     * starts the shutdown immediately if no conferences are currently being
+     * hosted. Otherwise jigasi will shutdown once all conferences expire.
+     */
+    public void enableGracefulShutdownMode()
+    {
+        if (!shutdownInProgress)
+        {
+            logger.info("Entered graceful shutdown mode");
+        }
+        this.shutdownInProgress = true;
+        maybeDoShutdown();
+    }
+
+    /**
+     * Returns {@code true} if this instance has entered graceful shutdown mode.
+     *
+     * @return {@code true} if this instance has entered graceful shutdown mode;
+     * otherwise, {@code false}
+     */
+    public boolean isShutdownInProgress()
+    {
+        return shutdownInProgress;
+    }
+
+    /**
+     * Triggers the shutdown given that we're in graceful shutdown mode and
+     * there are no conferences currently in progress.
+     */
+    private void maybeDoShutdown()
+    {
+        if (!shutdownInProgress)
+            return;
+
+        synchronized (sessions)
+        {
+            if (sessions.isEmpty())
+            {
+                this.stop();
+
+                ShutdownService shutdownService
+                    = ServiceUtils.getService(
+                    bundleContext,
+                    ShutdownService.class);
+
+                logger.info("Jigasi is shutting down NOW");
+                shutdownService.beginShutdown();
+            }
+        }
+    }
+
+    /**
+     * Adds a listener that will be notified of changes in our status.
+     *
+     * @param listener a gateway status listener.
+     */
+    public void addGatewayListener(GatewayListener listener)
+    {
+        synchronized(gatewayListeners)
+        {
+            if (!gatewayListeners.contains(listener))
+                gatewayListeners.add(listener);
+        }
+    }
+
+    /**
+     * Removes a listener that was being notified of changes in the status of
+     * the AbstractGateway.
+     *
+     * @param listener a gateway status listener.
+     */
+    public void removeGatewayListener(GatewayListener listener)
+    {
+        synchronized(gatewayListeners)
+        {
+            gatewayListeners.remove(listener);
+        }
+    }
+
+    /**
+     * Delivers event that new GatewaySession was added to active sessions.
+     * @param session the session that was added.
+     */
+    private void fireGatewaySessionAdded(AbstractGatewaySession session)
+    {
+        Iterable<GatewayListener> listeners;
+        synchronized (gatewayListeners)
+        {
+            listeners
+                = new ArrayList<>(gatewayListeners);
+        }
+
+        for (GatewayListener listener : listeners)
+        {
+            listener.onSessionAdded(session);
+        }
+    }
+
+    /**
+     * Delivers event that a GatewaySession was removed from active sessions.
+     * @param session the session that was removed.
+     */
+    private void fireGatewaySessionRemoved(AbstractGatewaySession session)
+    {
+        Iterable<GatewayListener> listeners;
+        synchronized (gatewayListeners)
+        {
+            listeners
+                = new ArrayList<>(gatewayListeners);
+        }
+
+        for (GatewayListener listener : listeners)
+        {
+            listener.onSessionRemoved(session);
+        }
+    }
+}

--- a/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
@@ -32,6 +32,7 @@ import java.util.*;
  * (outgoing or incoming).
  *
  * @author Pawel Domas
+ * @author Nik Vaessen
  */
 public abstract class AbstractGatewaySession
     implements OperationSetJitsiMeetTools.JitsiMeetRequestListener,

--- a/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
@@ -1,0 +1,259 @@
+/*
+ * Jigasi, the JItsi GAteway to SIP.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jigasi;
+
+import net.java.sip.communicator.service.protocol.*;
+import net.java.sip.communicator.service.protocol.event.*;
+import net.java.sip.communicator.service.protocol.media.*;
+import net.java.sip.communicator.util.Logger;
+import org.jitsi.jigasi.util.*;
+import org.jitsi.service.neomedia.*;
+import org.jitsi.util.*;
+
+import java.util.*;
+
+/**
+ * Class represents gateway session which manages single SIP call instance
+ * (outgoing or incoming).
+ *
+ * @author Pawel Domas
+ */
+public abstract class AbstractGatewaySession
+    implements OperationSetJitsiMeetTools.JitsiMeetRequestListener,
+               DTMFListener
+{
+    /**
+     * The logger.
+     */
+    private final static Logger logger = Logger.getLogger(
+        AbstractGatewaySession.class);
+
+    /**
+     * The <tt>AbstractGateway</tt> that manages this session.
+     */
+    protected AbstractGateway gateway;
+
+    /**
+     * The call context assigned for the current call.
+     */
+    protected CallContext callContext;
+
+    /**
+     * The <tt>JvbConference</tt> that handles current JVB conference.
+     */
+    protected JvbConference jvbConference;
+
+    /**
+     * Gateway session listeners.
+     */
+    private final ArrayList<GatewaySessionListener> listeners
+            = new ArrayList<>();
+
+    /**
+     * Global participant count during this session including the focus.
+     */
+    private int participantsCount = 0;
+
+    /**
+     * Creates new <tt>AbstractGatewaySession</tt> that can be used to
+     * join a conference by using the {@link #createOutgoingCall()} method.
+     *
+     * @param gateway the {@link AbstractGateway} the <tt>AbstractGateway</tt>
+     *                instance that will control this session.
+     * @param callContext the call context that identifies this session.
+     */
+    public AbstractGatewaySession(AbstractGateway gateway,
+                                  CallContext callContext)
+    {
+        this.gateway = gateway;
+        this.callContext = callContext;
+    }
+
+    /**
+     * Starts new outgoing session by joining JVB conference held in given
+     * MUC room.
+     */
+    public void createOutgoingCall()
+    {
+        if (jvbConference != null)
+        {
+            throw new IllegalStateException("Conference in progress");
+        }
+
+        jvbConference = new JvbConference(this, callContext);
+        jvbConference.start();
+    }
+
+    /**
+     * Returns the call context for the current session.
+
+     * @return the call context for the current session.
+     */
+    public CallContext getCallContext()
+    {
+        return callContext;
+    }
+
+    /**
+     * Returns the name of the chat room that holds current JVB conference or
+     * <tt>null</tt> we're not in any room.
+     *
+     * @return the name of the chat room that holds current JVB conference or
+     *         <tt>null</tt> we're not in any room.
+     */
+    public String getJvbRoomName()
+    {
+        return jvbConference != null ? jvbConference.getRoomName() : null;
+    }
+
+    /**
+     * Returns <tt>ChatRoom</tt> that hosts JVB conference of this session
+     * if we're already/still in this room or <tt>null</tt> otherwise.
+     */
+    public ChatRoom getJvbChatRoom()
+    {
+        return jvbConference != null ? jvbConference.getJvbRoom() : null;
+    }
+
+    // FIXME: 17/07/17 undocumented before refactor
+    abstract void onConferenceCallInvited(Call incomingCall);
+
+    /**
+     * Method called by <tt>JvbConference</tt> to notify that JVB conference
+     * call has started.
+     *
+     * @param jvbConferenceCall JVB call instance.
+     * @return any <tt>Exception</tt> that might occurred during handling of the
+     *         event. FIXME: is this still needed ?
+     */
+    abstract Exception onConferenceCallStarted(Call jvbConferenceCall);
+
+    /**
+     * Method called by <tt>JvbConference</tt> to notify that JVB call has
+     * ended.
+     *
+     * @param jvbConference <tt>JvbConference</tt> instance.
+     */
+    // FIXME: 17/07/17 reasonCode and reason are undocumented before refactor
+    abstract void onJvbConferenceStopped(JvbConference jvbConference,
+                                         int reasonCode, String reason);
+
+    /**
+     * Cancels current session by leaving the muc room
+     */
+    public void hangUp()
+    {
+        if (jvbConference != null)
+        {
+            jvbConference.stop();
+        }
+    }
+
+    /**
+     * Adds new {@link GatewaySessionListener} on this instance.
+     * @param listener adds new {@link GatewaySessionListener} that will receive
+     *                 updates from this instance.
+     */
+    public void addListener(GatewaySessionListener listener)
+    {
+        synchronized(listeners)
+        {
+            if (!listeners.contains(listener))
+                listeners.add(listener);
+        }
+    }
+
+    /**
+     * Removes {@link GatewaySessionListener} from this instance.
+     * @param listener removes {@link GatewaySessionListener} that will  stop
+     *                 receiving updates from this instance.
+     */
+    public void removeListener(GatewaySessionListener listener)
+    {
+        synchronized(listeners)
+        {
+            listeners.remove(listener);
+        }
+    }
+
+    /**
+     * Method called by {@link JvbConference} to notify session that it has
+     * joined the room.
+     *
+     * This method Notifies {@link GatewaySessionListener}(if any) that we have
+     * just joined the conference room(call is not started yet - just the MUC).
+     */
+    void notifyJvbRoomJoined()
+    {
+        // set initial participant count
+        participantsCount += getJvbChatRoom().getMembersCount();
+
+        Iterable<GatewaySessionListener> gwListeners;
+        synchronized (listeners)
+        {
+            gwListeners = new ArrayList<>(listeners);
+        }
+
+        for (GatewaySessionListener listener : gwListeners)
+        {
+            listener.onJvbRoomJoined(this);
+        }
+    }
+
+    /**
+     * Method called by {@link JvbConference} to notify session that a member
+     * has joined the room
+     *
+     * Notifies {@link GatewaySessionListener} that member just joined
+     * the conference room(MUC) and increments the participant counter
+     *
+     * @param member the member who joined the JVB conference
+     */
+    // FIXME: 17/07/17 original documentation is wrong. the listener does not
+    // even contain such a method
+    void notifyMemberJoined(ChatRoomMember member)
+    {
+        participantsCount++;
+    }
+
+    /**
+     * Method called by {@link JvbConference} to notify session that a member
+     * has left the room.
+     *
+     * Nothing needs to done in abstract class, but
+     * implementation might not actually care; thus not abstract.
+     *
+     * @param member the member who left the JVB conference
+     */
+    // FIXME: 17/07/17 JvbConference does not yet call this method
+    void notifyMemberLeft(ChatRoomMember member)
+    {
+    }
+
+    /**
+     * Returns the cumulative number of participants that were active during
+     * this session including the focus.
+     *
+     * @return the participants count.
+     */
+    public int getParticipantsCount()
+    {
+        return participantsCount;
+    }
+
+}

--- a/src/main/java/org/jitsi/jigasi/GatewayListener.java
+++ b/src/main/java/org/jitsi/jigasi/GatewayListener.java
@@ -21,6 +21,7 @@ package org.jitsi.jigasi;
  * Class used to listen for various {@link SipGateway} state changes.
  *
  * @author Damian Minkov
+ * @author Nik Vaessen
  */
 public interface GatewayListener
 {

--- a/src/main/java/org/jitsi/jigasi/GatewayListener.java
+++ b/src/main/java/org/jitsi/jigasi/GatewayListener.java
@@ -22,17 +22,17 @@ package org.jitsi.jigasi;
  *
  * @author Damian Minkov
  */
-public interface SipGatewayListener
+public interface GatewayListener
 {
     /**
      * Called when new session is added to the list of active sessions.
      * @param session the session that was added.
      */
-    void onSessionAdded(GatewaySession session);
+    void onSessionAdded(AbstractGatewaySession session);
 
     /**
      * Called when a session is removed from the list of active sessions.
      * @param session the session that was removed.
      */
-    void onSessionRemoved(GatewaySession session);
+    void onSessionRemoved(AbstractGatewaySession session);
 }

--- a/src/main/java/org/jitsi/jigasi/GatewaySessionListener.java
+++ b/src/main/java/org/jitsi/jigasi/GatewaySessionListener.java
@@ -23,6 +23,7 @@ package org.jitsi.jigasi;
  * changes.
  *
  * @author Pawel Domas
+ * @author Nik Vaessen
  */
 public interface GatewaySessionListener<T extends AbstractGatewaySession>
 {

--- a/src/main/java/org/jitsi/jigasi/GatewaySessionListener.java
+++ b/src/main/java/org/jitsi/jigasi/GatewaySessionListener.java
@@ -19,16 +19,18 @@ package org.jitsi.jigasi;
 
 
 /**
- * Class used to listen for various {@link GatewaySession} state changes.
+ * Class used to listen for various {@link AbstractGatewaySession} state
+ * changes.
  *
  * @author Pawel Domas
  */
-public interface GatewaySessionListener
+public interface GatewaySessionListener<T extends AbstractGatewaySession>
 {
     /**
-     * Called when SIP gateway session has joined the MUC and is now waiting for
-     * invite from the focus.
-     * @param source the {@link GatewaySession} on which the event takes place.
+     * Called when a <tt>AbstractGatewaySession</tt> has joined the MUC
+     *
+     * @param source the {@link AbstractGatewaySession} on which the event
+     *               takes place.
      */
-    void onJvbRoomJoined(GatewaySession source);
+    void onJvbRoomJoined(T source);
 }

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -43,6 +43,7 @@ import java.util.*;
  * {@link SipGateway} is notified about this fact and it handles it appropriate.
  *
  * @author Pawel Domas
+ * @author Nik Vaessen
  */
 public class JvbConference
     implements RegistrationStateChangeListener,

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -103,9 +103,9 @@ public class JvbConference
     }
 
     /**
-     * {@link GatewaySession} that uses this <tt>JvbConference</tt> instance.
+     * {@link SipGatewaySession} that uses this <tt>JvbConference</tt> instance.
      */
-    private final GatewaySession gatewaySession;
+    private final AbstractGatewaySession gatewaySession;
 
     /**
      * The XMPP account used for the call handled by this instance.
@@ -196,11 +196,11 @@ public class JvbConference
 
     /**
      * Creates new instance of <tt>JvbConference</tt>
-     * @param gatewaySession the <tt>GatewaySession</tt> that will be using this
-     *                       <tt>JvbConference</tt>.
+     * @param gatewaySession the <tt>SipGatewaySession</tt> that will be using
+     *                       this <tt>JvbConference</tt>.
      * @param ctx the call context of the current conference
      */
-    public JvbConference(GatewaySession gatewaySession, CallContext ctx)
+    public JvbConference(AbstractGatewaySession gatewaySession, CallContext ctx)
     {
         this.gatewaySession = gatewaySession;
         this.callContext = ctx;
@@ -256,19 +256,23 @@ public class JvbConference
     {
         String mucDisplayName = null;
 
-        String sipDestination = callContext.getDestination();
-        Call sipCall = gatewaySession.getSipCall();
+        // FIXME: 17/07/17 make JvbConference less reliant on SIP?
+        if(gatewaySession instanceof SipGatewaySession)
+        {
+            String sipDestination = callContext.getDestination();
+            Call sipCall = ((SipGatewaySession) gatewaySession).getSipCall();
 
-        if (sipDestination != null)
-        {
-            mucDisplayName = sipDestination;
-        }
-        else if (sipCall != null)
-        {
-            CallPeer firstPeer = sipCall.getCallPeers().next();
-            if (firstPeer != null)
+            if (sipDestination != null)
             {
-                mucDisplayName = firstPeer.getDisplayName();
+                mucDisplayName = sipDestination;
+            }
+            else if (sipCall != null)
+            {
+                CallPeer firstPeer = sipCall.getCallPeers().next();
+                if (firstPeer != null)
+                {
+                    mucDisplayName = firstPeer.getDisplayName();
+                }
             }
         }
 

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -733,6 +733,7 @@ public class JvbConference
     {
         logger.info("Member presence change: "+evt);
 
+        ChatRoomMember member = evt.getChatRoomMember();
         String eventType = evt.getEventType();
 
         if (!ChatRoomMemberPresenceChangeEvent.MEMBER_KICKED.equals(eventType)
@@ -742,17 +743,19 @@ public class JvbConference
             if (ChatRoomMemberPresenceChangeEvent.MEMBER_JOINED
                     .equals(eventType))
             {
-                gatewaySession.notifyMemberJoined(evt.getChatRoomMember());
+                gatewaySession.notifyMemberJoined(member);
             }
 
             return;
         }
+        else
+        {
+            gatewaySession.notifyMemberLeft(member);
+            logger.info(
+                    "Member left : " + member.getRole()
+                            + " " + member.getContactAddress());
+        }
 
-        ChatRoomMember member = evt.getChatRoomMember();
-
-        logger.info(
-            "Member left : " + member.getRole()
-                + " " + member.getContactAddress());
         // 2 members, us and the focus
         if (member.getContactAddress().equals(focusResourceAddr)
             || evt.getChatRoom().getMembersCount() == 2)

--- a/src/main/java/org/jitsi/jigasi/SipGateway.java
+++ b/src/main/java/org/jitsi/jigasi/SipGateway.java
@@ -29,6 +29,7 @@ import org.osgi.framework.*;
  * incoming SIP connections.
  *
  * @author Pawel Domas
+ * @author Nik Vaessen
  */
 public class SipGateway
     extends AbstractGateway<SipGatewaySession>

--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -34,6 +34,7 @@ import java.util.*;
  * (outgoing or incoming).
  *
  * @author Pawel Domas
+ * @author Nik Vaessen
  */
 public class SipGatewaySession
     extends AbstractGatewaySession

--- a/src/main/java/org/jitsi/jigasi/rest/HandlerImpl.java
+++ b/src/main/java/org/jitsi/jigasi/rest/HandlerImpl.java
@@ -90,7 +90,7 @@ import org.osgi.framework.*;
  */
 public class HandlerImpl
     extends AbstractJSONHandler
-    implements SipGatewayListener
+    implements GatewayListener
 {
     /**
      * The HTTP resource which is used to trigger graceful shutdown.
@@ -134,7 +134,7 @@ public class HandlerImpl
 
         if (this.gateway != null)
         {
-            this.gateway.addSipGatewayListener(this);
+            this.gateway.addGatewayListener(this);
         }
         else
         {
@@ -159,7 +159,7 @@ public class HandlerImpl
 
                     SipGateway sipGw = (SipGateway) service;
                     HandlerImpl.this.gateway = sipGw;
-                    sipGw.addSipGatewayListener(HandlerImpl.this);
+                    sipGw.addGatewayListener(HandlerImpl.this);
                 }
             });
         }
@@ -309,7 +309,7 @@ public class HandlerImpl
     }
 
     @Override
-    public void onSessionAdded(GatewaySession session)
+    public void onSessionAdded(AbstractGatewaySession session)
     {}
 
     /**
@@ -318,7 +318,7 @@ public class HandlerImpl
      * @param session the session that was removed.
      */
     @Override
-    public void onSessionRemoved(GatewaySession session)
+    public void onSessionRemoved(AbstractGatewaySession session)
     {
         Statistics.addTotalConferencesCount(1);
         Statistics.addTotalParticipantsCount(

--- a/src/main/java/org/jitsi/jigasi/rest/HandlerImpl.java
+++ b/src/main/java/org/jitsi/jigasi/rest/HandlerImpl.java
@@ -87,6 +87,7 @@ import org.osgi.framework.*;
  * </p>
  *
  * @author Damian Minkov
+ * @author Nik Vaessen
  */
 public class HandlerImpl
     extends AbstractJSONHandler

--- a/src/main/java/org/jitsi/jigasi/rest/Statistics.java
+++ b/src/main/java/org/jitsi/jigasi/rest/Statistics.java
@@ -32,6 +32,7 @@ import org.json.simple.*;
 /**
  * Implements statistics that are collected by the JIgasi.
  * @author Damian Minkov
+ * @author Nik Vaessen
  */
 public class Statistics
 {

--- a/src/main/java/org/jitsi/jigasi/rest/Statistics.java
+++ b/src/main/java/org/jitsi/jigasi/rest/Statistics.java
@@ -151,7 +151,7 @@ public class Statistics
 
         stats.put(CONFERENCES, gateway.getActiveSessions().size());
         int participants = 0;
-        for(GatewaySession ses : gateway.getActiveSessions())
+        for(SipGatewaySession ses : gateway.getActiveSessions())
         {
             if (ses.getJvbChatRoom() == null)
             {

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControl.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControl.java
@@ -29,6 +29,7 @@ import org.jivesoftware.smack.util.*;
  *  XMPP protocol for the purpose of SIP gateway calls management.
  *
  * @author Damian Minkov
+ * @author Nik Vaessen
  */
 public class CallControl
 {

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControl.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControl.java
@@ -157,7 +157,7 @@ public class CallControl
 
                 String callResource = hangUp.getTo();
 
-                GatewaySession session = gateway.getSession(callResource);
+                SipGatewaySession session = gateway.getSession(callResource);
 
                 if (session == null)
                     throw new RuntimeException(

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
@@ -44,6 +44,7 @@ import java.util.*;
  * The focus use the stats to load balance between instances.
  *
  * @author Damian Minkov
+ * @author Nik Vaessen
  */
 public class CallControlMucActivator
     implements BundleActivator,

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
@@ -50,7 +50,7 @@ public class CallControlMucActivator
                ServiceListener,
                RegistrationStateChangeListener,
                GatewaySessionListener,
-               SipGatewayListener,
+               GatewayListener,
                PacketFilter
 {
     /**
@@ -113,7 +113,7 @@ public class CallControlMucActivator
             bundleContext, SipGateway.class);
         if (gateway != null)
         {
-            gateway.addSipGatewayListener(this);
+            gateway.addGatewayListener(this);
 
             if (this.callControl == null)
                 this.callControl = new CallControl(gateway, config);
@@ -179,7 +179,7 @@ public class CallControlMucActivator
         else if (service instanceof SipGateway)
         {
             SipGateway gateway = (SipGateway) service;
-            gateway.addSipGatewayListener(this);
+            gateway.addGatewayListener(this);
 
             if (this.callControl == null)
                 this.callControl = new CallControl(
@@ -281,13 +281,13 @@ public class CallControlMucActivator
     }
 
     @Override
-    public void onJvbRoomJoined(GatewaySession source)
+    public void onJvbRoomJoined(AbstractGatewaySession source)
     {
         updatePresenceStatusForXmppProviders();
     }
 
     @Override
-    public void onSessionAdded(GatewaySession session)
+    public void onSessionAdded(AbstractGatewaySession session)
     {
         session.addListener(this);
         // we are not updating anything here (stats), cause session was just
@@ -297,7 +297,7 @@ public class CallControlMucActivator
     }
 
     @Override
-    public void onSessionRemoved(GatewaySession session)
+    public void onSessionRemoved(AbstractGatewaySession session)
     {
         updatePresenceStatusForXmppProviders();
         session.removeListener(this);
@@ -315,7 +315,7 @@ public class CallControlMucActivator
             osgiContext, SipGateway.class);
 
         int participants = 0;
-        for(GatewaySession ses : gateway.getActiveSessions())
+        for(SipGatewaySession ses : gateway.getActiveSessions())
         {
             participants += ses.getJvbChatRoom().getMembersCount();
         }
@@ -396,7 +396,7 @@ public class CallControlMucActivator
             osgiContext, SipGateway.class);
 
         int participants = 0;
-        for(GatewaySession ses : gateway.getActiveSessions())
+        for(SipGatewaySession ses : gateway.getActiveSessions())
         {
             participants += ses.getJvbChatRoom().getMembersCount();
         }

--- a/src/test/java/org/jitsi/jigasi/CallsHandlingTest.java
+++ b/src/test/java/org/jitsi/jigasi/CallsHandlingTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.*;
  * Test various call situations(not all :P).
  *
  * @author Pawel Domas
+ * @author Nik Vaessen
  */
 @RunWith(JUnit4.class)
 public class CallsHandlingTest

--- a/src/test/java/org/jitsi/jigasi/CallsHandlingTest.java
+++ b/src/test/java/org/jitsi/jigasi/CallsHandlingTest.java
@@ -138,7 +138,7 @@ public class CallsHandlingTest
         // once JVB conference is joined.
         callStateWatch.waitForState(sipCall, CallState.CALL_IN_PROGRESS, 1000);
 
-        GatewaySession session
+        SipGatewaySession session
             = osgi.getSipGateway().getActiveSessions().get(0);
 
         Call jvbCall = session.getJvbCall();
@@ -184,7 +184,7 @@ public class CallsHandlingTest
         ctx.setRoomName(roomName);
         ctx.setCustomCallResource("callResourceUri" + roomName);
 
-        GatewaySession session = sipGw.createOutgoingCall(ctx);
+        SipGatewaySession session = sipGw.createOutgoingCall(ctx);
         assertNotNull(session);
 
         Call sipCall = outCallWatch.getOutgoingCall(1000);
@@ -331,7 +331,7 @@ public class CallsHandlingTest
         callStateWatch.waitForState(sipCall, CallState.CALL_IN_PROGRESS, 1000);
 
         String callResource = callUri.substring(5);
-        GatewaySession session = osgi.getSipGateway().getSession(callResource);
+        SipGatewaySession session = osgi.getSipGateway().getSession(callResource);
         Call xmppCall = session.getJvbCall();
 
         // We joined JVB conference call
@@ -382,7 +382,7 @@ public class CallsHandlingTest
 
         // Now tear down, SIP calee ends the call
         // then XMPP cal should be terminated and MUC room left
-        GatewaySession session
+        SipGatewaySession session
             = osgi.getSipGateway().getActiveSessions().get(0);
         assertNotNull(session);
 
@@ -429,7 +429,7 @@ public class CallsHandlingTest
 
         // We expect to have 3 active sessions
         SipGateway gateway = osgi.getSipGateway();
-        List<GatewaySession> sessions = gateway.getActiveSessions();
+        List<SipGatewaySession> sessions = gateway.getActiveSessions();
 
         assertEquals(3, sessions.size());
 
@@ -490,10 +490,10 @@ public class CallsHandlingTest
 
         // We expect to have 1 active sessions
         SipGateway gateway = osgi.getSipGateway();
-        List<GatewaySession> sessions = gateway.getActiveSessions();
+        List<SipGatewaySession> sessions = gateway.getActiveSessions();
         assertEquals(1, sessions.size());
 
-        GatewaySession session1 = sessions.get(0);
+        SipGatewaySession session1 = sessions.get(0);
 
         GatewaySessionAsserts sessionWatch = new GatewaySessionAsserts();
         sessionWatch.assertJvbRoomJoined(session1, 1000);

--- a/src/test/java/org/jitsi/jigasi/GatewaySessionAsserts.java
+++ b/src/test/java/org/jitsi/jigasi/GatewaySessionAsserts.java
@@ -22,7 +22,7 @@ import net.java.sip.communicator.service.protocol.*;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Class encapsulates some assertions about {@link GatewaySession}.
+ * Class encapsulates some assertions about {@link SipGatewaySession}.
  *
  * @author Pawel Domas
  */
@@ -30,7 +30,7 @@ public class GatewaySessionAsserts
     implements GatewaySessionListener
 {
     @Override
-    public void onJvbRoomJoined(GatewaySession source)
+    public void onJvbRoomJoined(AbstractGatewaySession source)
     {
         synchronized (this)
         {
@@ -38,7 +38,7 @@ public class GatewaySessionAsserts
         }
     }
 
-    public void assertJvbRoomJoined(GatewaySession session, long timeout)
+    public void assertJvbRoomJoined(AbstractGatewaySession session, long timeout)
         throws InterruptedException
     {
         synchronized (this)

--- a/src/test/java/org/jitsi/jigasi/GatewaySessionAsserts.java
+++ b/src/test/java/org/jitsi/jigasi/GatewaySessionAsserts.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
  * Class encapsulates some assertions about {@link SipGatewaySession}.
  *
  * @author Pawel Domas
+ * @author Nik Vaessen
  */
 public class GatewaySessionAsserts
     implements GatewaySessionListener


### PR DESCRIPTION
This pr splits up Sipgateway into an AbstractGateway which is now extended by SipGateway.
The same happened to GatewaySession, creating an AbstractGatewaySession which only has code regarding joining a conference and SipgatewaySession, which is the old GatewaySession.

Due to these changes the SipGatewayListener and GatewaySessionListener have been modified to now
listen for the abstract versions. 

Includes minor changes in other classes (mainly changes types to SipGatewaySession)

Also adds a notification for members leaving a conference (from JvbConference to AbstractGatewaySession)