### PR TITLE
add check for XMPP translator support and overwrite property when it is not supported by a GatewaySession

### DIFF
--- a/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
@@ -265,4 +265,12 @@ public abstract class AbstractGatewaySession
      */
     public abstract String getMucDisplayName();
 
+    /**
+     * Get whether this GatewaySession will work when xmpp uses translator in
+     * conference
+     *
+     * @return true when this GatewaySession will work with translator, false
+     * otherwise
+     */
+    public abstract boolean isTranslatorSupported();
 }

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1081,6 +1081,14 @@ public class JvbConference
         String accountUID = "Jabber:" + userID + "/" + resourceName;
         properties.put(ProtocolProviderFactory.ACCOUNT_UID, accountUID);
 
+        // Because some AbstractGatewaySessions needs access to the audio,
+        // we can't always use translator
+        if(!gatewaySession.isTranslatorSupported())
+        {
+            properties.put(ProtocolProviderFactory.USE_TRANSLATOR_IN_CONFERENCE,
+                "false");
+        }
+
         return properties;
     }
 

--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -572,6 +572,12 @@ public class SipGatewaySession
         }
     }
 
+    @Override
+    public boolean isTranslatorSupported()
+    {
+        return true;
+    }
+
     /**
      * Adds a ssrc rewriter to the peers media stream.
      * @param peer the peer which media streams to manipulate

--- a/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
@@ -202,6 +202,12 @@ public class TranscriptionGatewaySession
         }
     }
 
+    @Override
+    public boolean isTranslatorSupported()
+    {
+        return false;
+    }
+
     /**
      * Find the ConferenceMember which has the same ID as the given
      * ChatRoomMember, if any exists


### PR DESCRIPTION
This allows the TranscriptionGatewaySession to still work when the following properties are set in sip-communicator.properties:

net.java.sip.communicator.impl.neomedia.audioSystem.audiosilence.captureDevice_list=["AudioSilenceCaptureDevice:noTransferData"]
org.jitsi.jigasi.xmpp.acc.USE_TRANSLATOR_IN_CONFERENCE=true