### PR TITLE
update build instructions in readme and provide scripts in zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,30 @@ It is possible to install Jigasi along with Jitsi Meet using our [quick install 
 
  ```
  cd jigasi
- ant make
+ mvn install -Dassembly.skipAssembly=false
  ```
- 
-3. Configure external component in your XMPP server. If your server is Prosody: edit /etc/prosody/prosody.cfg.lua and append following lines to your config (assuming that subdomain is 'callcontrol' and domain 'meet.jit.si'):
+
+3. Extract - choose either `jigasi-linux-x64-{version}.zip`, `jigasi-linux-x86-{version}.zip` or `jigasi-macosx-{version}.zip` based on the system.
+
+ ```
+ cd target/
+ unzip jigasi-{os-version}-{version}.zip
+ ```
+
+4. Configure external component in your XMPP server. If your server is Prosody: edit /etc/prosody/prosody.cfg.lua and append following lines to your config (assuming that subdomain is 'callcontrol' and domain 'meet.jit.si'):
 
  ```
  Component "callcontrol.meet.jit.si"
      component_secret = "topsecret"
  ```
-4. Setup SIP account
+5. Setup SIP account
 
  Go to jigasi/jigasi-home and edit sip-communicator.properties file. Replace ```<<JIGASI_SIPUSER>>``` tag with SIP username for example: "user1232@sipserver.net". Then put Base64 encoded password in place of ```<<JIGASI_SIPPWD>>```.
 
 5. Start Jigasi
  
  ```
+ cd jigasi/target/jigasi-{os-version}-{version}/
  ./jigasi.sh --domain=meet.jit.si --subdomain=callcontrol --secret=topsecret
  ```
 After Jigasi is started it will register as XMPP component under the 'callcontrol' subdomain. In Jitsi Meet application -> config.js -> hosts.call_control must be set to 'callcontrol.meet.jit.si'. This will enable SIP calls in Jitsi Meet.

--- a/src/assembly/linux-x64-bin-archive.xml
+++ b/src/assembly/linux-x64-bin-archive.xml
@@ -19,7 +19,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <includes>
         <include>*.jar</include>
       </includes>
@@ -38,11 +38,19 @@
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/resources/install/linux-64</directory>
-      <outputDirectory>/</outputDirectory>
+      <directory>${project.basedir}</directory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <fileMode>755</fileMode>
       <includes>
         <include>jigasi.sh</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/script</directory>
+      <outputDirectory>${file.separator}</outputDirectory>
+      <fileMode>755</fileMode>
+      <includes>
+        <include>graceful_shutdown.sh</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/assembly/linux-x86-bin-archive.xml
+++ b/src/assembly/linux-x86-bin-archive.xml
@@ -19,7 +19,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <includes>
         <include>*.jar</include>
       </includes>
@@ -38,11 +38,19 @@
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/resources/install/linux</directory>
-      <outputDirectory>/</outputDirectory>
+      <directory>${project.basedir}</directory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <fileMode>755</fileMode>
       <includes>
         <include>jigasi.sh</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/script</directory>
+      <outputDirectory>${file.separator}</outputDirectory>
+      <fileMode>755</fileMode>
+      <includes>
+        <include>graceful_shutdown.sh</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/assembly/macosx-bin-archive.xml
+++ b/src/assembly/macosx-bin-archive.xml
@@ -19,7 +19,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <includes>
         <include>*.jar</include>
       </includes>
@@ -38,11 +38,19 @@
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/resources/install/macosx</directory>
-      <outputDirectory>/</outputDirectory>
+      <directory>${project.basedir}</directory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <fileMode>755</fileMode>
       <includes>
         <include>jigasi.sh</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/script</directory>
+      <outputDirectory>${file.separator}</outputDirectory>
+      <fileMode>755</fileMode>
+      <includes>
+        <include>graceful_shutdown.sh</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
Also fixes the warning: 

`[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /
`

when building. Only warning left:

`[WARNING] Invalid POM for org.jitsi:jitsi-videobridge:jar:1.0-SNAPSHOT, transitive dependencies (if any) will not be available, enable debug logging for more details
`