### PR TITLE
Leave whack version to come from jicoco dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <dependency>
       <groupId>org.igniterealtime.whack</groupId>
       <artifactId>core</artifactId>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.gagravarr</groupId>


### PR DESCRIPTION
Seems the problem is using an older(2.0.0) whack version, while jicoco uses 2.0.1. This should fix it, although I don't see to be fixed locally. I keep seeing that it depends: org.jitsi:jicoco:jar:1.1-SNAPSHOT:compile which depends on whack 2.0.0. But anyway whack should be coming with jicoco and should not be declared in jigasi.