### PR TITLE
disable 'initialising call' when transcriber joins

### DIFF
--- a/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
@@ -321,6 +321,14 @@ public abstract class AbstractGatewaySession
     public abstract boolean isTranslatorSupported();
 
     /**
+     * Get the default status of our participant before we get any state from
+     * the <tt>CallPeer</tt>.
+     *
+     * @return the default status, or null when none desired
+     */
+    public abstract String getDefaultInitStatus();
+
+    /**
      * Returns the gateway used for this session.
      * @return the gateway used for this session.
      */

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -98,12 +98,6 @@ public class JvbConference
         = "org.jitsi.jigasi.MUC_SERVICE_ADDRESS";
 
     /**
-     * Default status of our participant before we get any state from
-     * the <tt>CallPeer</tt>.
-     */
-    private static final String INIT_STATUS_NAME = "Initializing Call";
-
-    /**
      * The default bridge id to use.
      */
     public static final String DEFAULT_BRIDGE_ID = "jitsi";
@@ -661,7 +655,10 @@ public class JvbConference
               //  gatewaySession.createPresenceExtension(
                 //    SipGatewayExtension.STATE_CONNECTING_JVB, null));
 
-            setPresenceStatus(INIT_STATUS_NAME);
+            if(gatewaySession.getDefaultInitStatus() != null)
+            {
+                setPresenceStatus(gatewaySession.getDefaultInitStatus());
+            }
 
             gatewaySession.notifyJvbRoomJoined();
 

--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -98,6 +98,12 @@ public class SipGatewaySession
         = "JITSI_MEET_DOMAIN_BASE_HEADER_NAME";
 
     /**
+     * Default status of our participant before we get any state from
+     * the <tt>CallPeer</tt>.
+     */
+    private static final String INIT_STATUS_NAME = "Initializing Call";
+
+    /**
      * The {@link OperationSetJitsiMeetTools} for SIP leg.
      */
     private final OperationSetJitsiMeetTools jitsiMeetTools;
@@ -622,6 +628,15 @@ public class SipGatewaySession
     public boolean isTranslatorSupported()
     {
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDefaultInitStatus()
+    {
+        return INIT_STATUS_NAME;
     }
 
     /**

--- a/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
@@ -278,6 +278,14 @@ public class TranscriptionGatewaySession
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDefaultInitStatus()
+    {
+        return null;
+    }
 
     /**
      * This method will be called by the {@link Transcriber} every time a new


### PR DESCRIPTION
This PR disables the 'initialising call' presence update when the Transcriber joins a conference.