### PR TITLE
Sets source language for transcription with presence update

### DIFF
--- a/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
@@ -267,21 +267,34 @@ public class TranscriptionGatewaySession
         super.notifyChatRoomMemberUpdated(chatMember, presence);
 
         String identifier = getParticipantIdentifier(chatMember);
+        TranscriptionLanguageExtension transcriptionLanguageExtension
+            = presence.getExtension(
+                TranscriptionLanguageExtension.ELEMENT_NAME,
+                TranscriptionLanguageExtension.NAMESPACE);
         TranslationLanguageExtension translationLanguageExtension
             = presence.getExtension(
                 TranslationLanguageExtension.ELEMENT_NAME,
                 TranslationLanguageExtension.NAMESPACE);
+
+        if(transcriptionLanguageExtension != null)
+        {
+            String language
+                = transcriptionLanguageExtension.getTranscriptionLanguage();
+
+            this.transcriber.updateParticipantSourceLanguage(identifier,
+                language);
+        }
 
         if(translationLanguageExtension != null)
         {
             String language
                 = translationLanguageExtension.getTranslationLanguage();
 
-            this.transcriber.updateParticipantLanguage(identifier, language);
+            this.transcriber.updateParticipantTargetLanguage(identifier, language);
         }
         else
         {
-            this.transcriber.updateParticipantLanguage(identifier, null);
+            this.transcriber.updateParticipantTargetLanguage(identifier, null);
         }
     }
 

--- a/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
@@ -309,13 +309,32 @@ public class Transcriber
 
     /**
      * Update the {@link Participant} with the given identifier by setting the
+     * <tt>sourceLanguageLocale</tt> of the participant.
+     *
+     * @param identifier the identifier of the participant
+     * @param language the source language tag for the participant
+     */
+    public void updateParticipantSourceLanguage(String identifier,
+                                                String language)
+    {
+        Participant participant = getParticipant(identifier);
+
+        if(participant != null)
+        {
+            participant.setSourceLanguage(language);
+        }
+    }
+
+    /**
+     * Update the {@link Participant} with the given identifier by setting the
      * <tt>translationLanguage</tt> of the participant and update the count for
      * languages in the @link {@link TranslationManager}
      *
      * @param identifier the identifier of the participant
      * @param language the language tag to be updated for the participant
      */
-    public void updateParticipantLanguage(String identifier, String language)
+    public void updateParticipantTargetLanguage(String identifier,
+                                                String language)
     {
         Participant participant = getParticipant(identifier);
 


### PR DESCRIPTION
- [x] Relies on [jitsi/jitsi#509](https://github.com/jitsi/jitsi/pull/509).
- [ ] pom.xml to be updated with the new jitsi-desktop-version.
Source language can be set by : 
`APP.conference._room.setLocalParticipantProperty('transcription_language','hi-IN');`