### PR TITLE
catch "deallocate cannot be used on a started conference" exceptions

### DIFF
--- a/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
@@ -31,6 +31,7 @@ import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
 import org.jxmpp.stringprep.*;
 
+import javax.media.*;
 import java.util.*;
 
 /**
@@ -157,7 +158,9 @@ public class TranscriptionGatewaySession
 
         // We create a MediaWareCallConference whose MediaDevice
         // will get the get all of the audio and video packets
-        jvbConferenceCall.setConference(new MediaAwareCallConference()
+        try
+        {
+            jvbConferenceCall.setConference(new MediaAwareCallConference()
             {
                 @Override
                 public MediaDevice getDefaultDevice(MediaType mediaType,
@@ -172,6 +175,12 @@ public class TranscriptionGatewaySession
                     return super.getDefaultDevice(mediaType, useCase);
                 }
             });
+        }
+        catch (ClockStartedError e)
+        {
+            jvbConference.stop();
+            throw new RuntimeException(e);
+        }
 
         // adds all TranscriptionEventListener among TranscriptResultPublishers
         for (TranscriptionResultPublisher pub

--- a/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
@@ -178,6 +178,11 @@ public class TranscriptionGatewaySession
         }
         catch (ClockStartedError e)
         {
+            TranscriptionStatusExtension extension
+                = new TranscriptionStatusExtension();
+            extension.setStatus(TranscriptionStatusExtension.Status.OFF);
+            jvbConference.sendPresenceExtension(extension);
+
             jvbConference.stop();
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This will make Jigasi leave the conference, but the session needs to be restarted in order for a reinvite to appear as jicofo will not be told that TranscriptionStatus = off, as the exception causes updating presence to fail.