### PR TITLE
Few improvements.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
-    <smack.version>4.2.1</smack.version>
+    <smack.version>4.2.4-47d17fc</smack.version>
     <jitsi-desktop.version>2.13.5160aa9</jitsi-desktop.version>
   </properties>
 
@@ -50,6 +50,16 @@
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-extensions</artifactId>
+      <version>${smack.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-bosh</artifactId>
+      <version>${smack.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-tcp</artifactId>
       <version>${smack.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -830,7 +830,7 @@ public class JvbConference
         }
 
         // if it is the focus leaving
-        if (member.getContactAddress().equals(focusResourceAddr))
+        if (member.getName().equals(focusResourceAddr))
         {
             logger.info("Focus left! - stopping");
             stop();
@@ -861,7 +861,6 @@ public class JvbConference
     public void localUserPresenceChanged(
         LocalUserChatRoomPresenceChangeEvent evt)
     {
-
         if (evt.getChatRoom().equals(JvbConference.this.mucRoom)
             && Objects.equals(evt.getEventType(),
                     LocalUserChatRoomPresenceChangeEvent.LOCAL_USER_KICKED))

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1332,14 +1332,22 @@ public class JvbConference
             this.errorLog = errorLog;
         }
 
+        /**
+         * Schedules a new timeout thread if not already scheduled.
+         *
+         * @param timeout the milliseconds to wait before we stop the conference
+         * if not canceled.
+         */
         void scheduleTimeout(long timeout)
         {
             synchronized (syncRoot)
             {
-                this.timeout = timeout;
-
                 if (timeoutThread != null)
-                    throw new IllegalStateException("already scheduled");
+                {
+                    return;
+                }
+
+                this.timeout = timeout;
 
                 timeoutThread = new Thread(this, name);
                 willCauseTimeout = true;

--- a/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
@@ -132,6 +132,26 @@ public class TranscriptionGatewaySession
         transcriber.setRoomName(getJvbRoomName());
         transcriber.setRoomUrl(getMeetingUrl());
 
+        // We create a MediaWareCallConference whose MediaDevice
+        // will get the get all of the audio and video packets
+        incomingCall.setConference(new MediaAwareCallConference()
+        {
+            @Override
+            public MediaDevice getDefaultDevice(MediaType mediaType,
+                MediaUseCase useCase)
+            {
+                if(MediaType.AUDIO.equals(mediaType))
+                {
+                    logger.info("Transcriber: Media Device Audio");
+                    return transcriber.getMediaDevice();
+                }
+                logger.info("Transcriber: Media Device Video");
+                // FIXME: 18/07/17 what to do with video?
+                // will cause an exception when mediaType == VIDEO
+                return super.getDefaultDevice(mediaType, useCase);
+            }
+        });
+
         logger.debug("Invited for conference");
     }
 
@@ -154,24 +174,6 @@ public class TranscriptionGatewaySession
             jvbConference.stop();
             return null;
         }
-
-        // We create a MediaWareCallConference whose MediaDevice
-        // will get the get all of the audio and video packets
-        jvbConferenceCall.setConference(new MediaAwareCallConference()
-            {
-                @Override
-                public MediaDevice getDefaultDevice(MediaType mediaType,
-                                                    MediaUseCase useCase)
-                {
-                    if(MediaType.AUDIO.equals(mediaType))
-                    {
-                        return transcriber.getMediaDevice();
-                    }
-                    // FIXME: 18/07/17 what to do with video?
-                    // will cause an exception when mediaType == VIDEO
-                    return super.getDefaultDevice(mediaType, useCase);
-                }
-            });
 
         // adds all TranscriptionEventListener among TranscriptResultPublishers
         for (TranscriptionResultPublisher pub

--- a/src/main/java/org/jitsi/jigasi/transcription/AbstractTranscriptPublisher.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/AbstractTranscriptPublisher.java
@@ -227,10 +227,20 @@ public abstract class AbstractTranscriptPublisher<T>
             logger.error("Cannot sent message as chatRoom is null");
             return;
         }
+
         if (!(chatRoom instanceof ChatRoomJabberImpl))
         {
             logger.error("Cannot sent message as chatRoom is not an" +
                 "instance of ChatRoomJabberImpl");
+            return;
+        }
+
+        if (!chatRoom.isJoined())
+        {
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("Skip sending message to room which we left!");
+            }
             return;
         }
 


### PR DESCRIPTION
Few fixes for exceptions I saw during testing.

Fixes memory leak, leaking and not disconnecting bosh connections. I still see the nginx server timeout, but it is very rear and I still see it on the muc control connection, which reconnects maybe some timing need to be tuned.

I was reproducing 10-20% of the times not working transcription, moving the setConference call earlier (before answering the call) fixes it for me.

Sometimes I was seeing the conference to timeout, and this was because kick of the transcription participant was not detected in the code. Sometimes the listener for the kick is invoked and sometimes the participant leave one by one and we were not detecting correctly that the focus has left.