### PR TITLE
Enable the use of better performing "video model" of Google Speech API

### DIFF
--- a/jigasi-home/sip-communicator.properties
+++ b/jigasi-home/sip-communicator.properties
@@ -106,6 +106,10 @@ org.jitsi.jigasi.xmpp.acc.VIDEO_CALLING_DISABLED=true
 #org.jitsi.jigasi.ENABLE_TRANSCRIPTION=false
 #org.jitsi.jigasi.ENABLE_SIP=true
 
+# whether to use the more expensive, but better performing
+# "video" model when doing transcription
+# org.jitsi.jigasi.transcription.USE_VIDEO_MODEL = false
+
 # delivering final transcript
 # org.jitsi.jigasi.transcription.DIRECTORY=/var/lib/jigasi/transcripts
 # org.jitsi.jigasi.transcription.BASE_URL=http://localhost/

--- a/pom.xml
+++ b/pom.xml
@@ -27,17 +27,17 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>23.0</version>
+      <version>27.0-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-speech</artifactId>
-      <version>0.49.0-alpha</version>
+      <version>0.68.0-beta</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-translate</artifactId>
-      <version>1.31.0</version>
+      <version>1.50.0</version>
     </dependency>
     <dependency>
       <groupId>dom4j</groupId>

--- a/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
@@ -132,7 +132,7 @@ public class Transcriber
      * for managing translations.
      */
     private TranslationManager translationManager
-        = new TranslationManager(new GoogleCloudTranslationService());;
+        = new TranslationManager(new GoogleCloudTranslationService());
 
     /**
      * Every listener which will be notified when a new result comes in


### PR DESCRIPTION
Good news! The video model of the Google Cloud speech-to-text API can now be used. While it's more expensive to use, it also offers better transcription capabilities.

When this model was initially released in May 2018 it was not able to return IS_FINAL results. However, after trying to implement it again now it turns it is does return IS_FINAL results, making it possible to close the current StreamingSession and open a new one without having to do VAD ourselves. 