### PR TITLE
Updates jitsi dependency to 2.13.4056694.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
     <smack.version>4.2.4-47d17fc</smack.version>
-    <jitsi-desktop.version>2.13.464e576</jitsi-desktop.version>
+    <jitsi-desktop.version>2.13.4056694</jitsi-desktop.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Can successfully disable jingle-nodes which leaks connections. Disables
port tracker ot increase ports without checking range, which can lead to
 healthchecks failing. Fixes setting keep-alive interval for xmpp
 accounts.