### PR TITLE
Update ScServiceDiscoveryManager to use smacks implementation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
-    <jitsi-desktop.version>2.13.b5f2aa0</jitsi-desktop.version>
+    <jitsi-desktop.version>2.13.3ee5751</jitsi-desktop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.26</slf4j.version>
     <smack.version>4.2.4-47d17fc</smack.version>

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-20190408.170703-2</version>
+      <version>1.0-20190411.124339-4</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/src/main/java/org/jitsi/jigasi/Main.java
+++ b/src/main/java/org/jitsi/jigasi/Main.java
@@ -156,11 +156,15 @@ public class Main
         = new String[]
         {
             "org.jivesoftware.smackx.iqlast",
+            "org.jivesoftware.smackx.bytestreams",
+            "org.jivesoftware.smackx.filetransfer",
+            "org.jivesoftware.smackx.hoxt",
+            "org.jivesoftware.smackx.si",
+            "org.jivesoftware.smackx.vcardtemp",
+            "org.jivesoftware.smackx.xhtmlim",
             "org.jivesoftware.smackx.xdata",
             "org.jivesoftware.smackx.eme",
-            "org.jivesoftware.smackx.bytestreams.socks5",
             "org.jivesoftware.smackx.iqprivate",
-            "org.jivesoftware.smackx.bytestreams.ibb",
             "org.jivesoftware.smackx.bookmarks",
             "org.jivesoftware.smackx.receipts",
             "org.jivesoftware.smackx.commands",


### PR DESCRIPTION
Before merging, jitsi-desktop version needs to be updated after merging jitsi/jitsi#587
