### PR TITLE
Detects incoming media dropped on sip side.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20190412.160239-384</version>
+      <version>1.0-20190605.073004-385</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
@@ -69,7 +69,7 @@ public abstract class AbstractGatewaySession
     private int participantsCount = 0;
 
     /**
-     * Whether we receive media from the gateway side.
+     * Whether media had stopped being received from the gateway side.
      */
     protected boolean gatewayMediaDropped = false;
 

--- a/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
@@ -69,6 +69,11 @@ public abstract class AbstractGatewaySession
     private int participantsCount = 0;
 
     /**
+     * Whether we receive media from the gateway side.
+     */
+    protected boolean gatewayMediaDropped = false;
+
+    /**
      * Creates new <tt>AbstractGatewaySession</tt> that can be used to
      * join a conference by using the {@link #createOutgoingCall()} method.
      *
@@ -370,5 +375,15 @@ public abstract class AbstractGatewaySession
     void notifyConferenceMemberLeft(ConferenceMember conferenceMember)
     {
         // we don't have anything to do here
+    }
+
+    /**
+     * Returns whether current gateway is up and running and media is being
+     * received or it was dropped.
+     * @return current gateway media status.
+     */
+    public boolean isGatewayMediaDropped()
+    {
+        return gatewayMediaDropped;
     }
 }

--- a/src/main/java/org/jitsi/jigasi/stats/Statistics.java
+++ b/src/main/java/org/jitsi/jigasi/stats/Statistics.java
@@ -188,7 +188,7 @@ public class Statistics
         stats.put(TOTAL_NUMBEROFPARTICIPANTS, totalParticipantsCount);
         stats.put(TOTAL_CONFERENCE_SECONDS, cumulativeConferenceSeconds);
         stats.put(TOTAL_CALLS_WITH_DROPPED_MEDIA,
-            totalCallsWithMediaDroppedCount);
+            totalCallsWithMediaDroppedCount.get());
 
 
         stats.put(SHUTDOWN_IN_PROGRESS,

--- a/src/main/java/org/jitsi/jigasi/stats/Statistics.java
+++ b/src/main/java/org/jitsi/jigasi/stats/Statistics.java
@@ -21,6 +21,7 @@ import java.io.*;
 import java.lang.management.*;
 import java.text.*;
 import java.util.*;
+import java.util.concurrent.atomic.*;
 import java.util.stream.*;
 
 import javax.servlet.http.*;
@@ -128,6 +129,12 @@ public class Statistics
     private static int totalConferencesCount = 0;
 
     /**
+     * Total number of calls with dropped media since started.
+     */
+    private static AtomicLong totalCallsWithMediaDroppedCount
+        = new AtomicLong();
+
+    /**
      * Cumulative number of seconds of all conferences.
      */
     private static long cumulativeConferenceSeconds = 0;
@@ -180,6 +187,9 @@ public class Statistics
         stats.put(TOTAL_CONFERENCES, totalConferencesCount);
         stats.put(TOTAL_NUMBEROFPARTICIPANTS, totalParticipantsCount);
         stats.put(TOTAL_CONFERENCE_SECONDS, cumulativeConferenceSeconds);
+        stats.put(TOTAL_CALLS_WITH_DROPPED_MEDIA,
+            totalCallsWithMediaDroppedCount);
+
 
         stats.put(SHUTDOWN_IN_PROGRESS,
             JigasiBundleActivator.isShutdownInProgress());
@@ -206,7 +216,6 @@ public class Statistics
 
         int participants = 0;
         int conferences = 0;
-        int mediaDropped = 0;
 
         for(AbstractGatewaySession ses : sessions)
         {
@@ -228,18 +237,10 @@ public class Statistics
                 conferenceSizes[idx]++;
             }
             conferences++;
-
-            if (ses.isGatewayMediaDropped())
-            {
-                mediaDropped++;
-            }
         }
 
         // CONFERENCES
         stats.put(CONFERENCES, conferences);
-
-        // TOTAL_CALLS_WITH_DROPPED_MEDIA
-        stats.put(TOTAL_CALLS_WITH_DROPPED_MEDIA, mediaDropped);
 
         // CONFERENCE_SIZES
         JSONArray conferenceSizesJson = new JSONArray();
@@ -279,6 +280,14 @@ public class Statistics
     public static void addTotalConferencesCount(int value)
     {
         totalConferencesCount += value;
+    }
+
+    /**
+     * Increment the value of total number of calls with dropped media.
+     */
+    public static void incrementTotalCallsWithMediaDropped()
+    {
+        totalCallsWithMediaDroppedCount.incrementAndGet();
     }
 
     /**

--- a/src/main/java/org/jitsi/jigasi/stats/Statistics.java
+++ b/src/main/java/org/jitsi/jigasi/stats/Statistics.java
@@ -110,6 +110,14 @@ public class Statistics
         = "total_conference_seconds";
 
     /**
+     * The name of the number of conferences which do not receive media from
+     * the gateway side.
+     * {@code Integer}.
+     */
+    public static final String TOTAL_CALLS_WITH_DROPPED_MEDIA
+        = "total_calls_with_dropped_media";
+
+    /**
      * Total number of participants since started.
      */
     private static int totalParticipantsCount = 0;
@@ -198,6 +206,7 @@ public class Statistics
 
         int participants = 0;
         int conferences = 0;
+        int mediaDropped = 0;
 
         for(AbstractGatewaySession ses : sessions)
         {
@@ -219,10 +228,18 @@ public class Statistics
                 conferenceSizes[idx]++;
             }
             conferences++;
+
+            if (ses.isGatewayMediaDropped())
+            {
+                mediaDropped++;
+            }
         }
 
         // CONFERENCES
         stats.put(CONFERENCES, conferences);
+
+        // TOTAL_CALLS_WITH_DROPPED_MEDIA
+        stats.put(TOTAL_CALLS_WITH_DROPPED_MEDIA, mediaDropped);
 
         // CONFERENCE_SIZES
         JSONArray conferenceSizesJson = new JSONArray();


### PR DESCRIPTION
If we detect dropped media, print messages, add stats and when it
resumes stat is updated and message is printed that RTP resumed.
The setting is a threshold of time after which we consider media
for dropped, -1 disables the behaviour, default is 10 seconds and
enabled. There is also an option that, when enabled, calls can be
dropped when media stops.