### PR TITLE
Jigasi stats update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-stats</artifactId>
-      <version>1.0-20190407.140545-7</version>
+      <version>1.0-20190606.142627-9</version>
     </dependency>
     <dependency>
       <!--

--- a/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
+++ b/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
@@ -181,7 +181,6 @@ public class StatsHandler
                 bundleContext,
                 ProtocolProviderService.class);
 
-
             for (ServiceReference<ProtocolProviderService> serviceRef
                 : providers)
             {
@@ -204,8 +203,33 @@ public class StatsHandler
 
         if (targetAccountID == null)
         {
-            logger.debug("No account found with enabled stats");
-            return;
+            // No account found with enabled stats
+            // we are maybe in the case where there are no xmpp control accounts
+            // this is when outgoing calls are disabled
+            // and we have only the xmpp client account, which may have the
+            // callstats settings
+
+            for (Call confCall : call.getConference().getCalls())
+            {
+                if (confCall.getProtocolProvider().getProtocolName()
+                    .equals(ProtocolNames.JABBER))
+                {
+                    AccountID acc = confCall.getProtocolProvider()
+                        .getAccountID();
+                    if (acc.getAccountPropertyInt(CS_ACC_PROP_APP_ID, 0) != 0)
+                    {
+                        // there are callstats settings then use it
+                        targetAccountID = acc;
+                    }
+                }
+            }
+
+            if (targetAccountID == null)
+            {
+                logger.debug("No account found with enabled stats");
+
+                return;
+            }
         }
 
         int appId

--- a/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
+++ b/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
@@ -269,6 +269,7 @@ public class StatsHandler
                     keyId,
                     keyPath,
                     jigasiId,
+                    true,
                     ((reason, errorMessage) -> {
                         logger.error("Jitsi-stats library failed to initialize "
                             + "with reason: " + reason


### PR DESCRIPTION
Two changes:
- update to latest jitsi-stats to be able to indicate stats as for client (browser endpoint)
- get callstats config and from the client account props. This covers the case where there are no xmpp control accounts (dial out is disabled) and we still want to enable callstats.