### PR TITLE
Updates stats to include originID as jigasi-number.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1068,7 +1068,8 @@ public class JvbConference
 
             if (statsHandler == null)
             {
-                statsHandler = new StatsHandler(DEFAULT_BRIDGE_ID);
+                statsHandler = new StatsHandler(
+                    gatewaySession.getMucDisplayName(), DEFAULT_BRIDGE_ID);
             }
             jvbCall.addCallChangeListener(statsHandler);
 

--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -487,6 +487,7 @@ public class SipGatewaySession
                 if (statsHandler == null)
                 {
                     statsHandler = new StatsHandler(
+                        destination,
                         DEFAULT_STATS_REMOTE_ID + "-" + destination);
                 }
                 call.addCallChangeListener(statsHandler);
@@ -595,8 +596,9 @@ public class SipGatewaySession
         // lets add cs to incoming call
         if (statsHandler == null)
         {
+            String displayName = this.getMucDisplayName();
             statsHandler = new StatsHandler(
-                DEFAULT_STATS_REMOTE_ID + "-" + this.getMucDisplayName());
+                displayName, DEFAULT_STATS_REMOTE_ID + "-" + displayName);
         }
         call.addCallChangeListener(statsHandler);
 

--- a/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
+++ b/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
@@ -115,12 +115,19 @@ public class StatsHandler
     private final String remoteEndpointID;
 
     /**
+     * The origin ID. From jigasi we always report jigasi-NUMBER as
+     * the origin ID.
+     */
+    private final String originID;
+
+    /**
      * Constructs StatsHandler.
      * @param remoteEndpointID the remote endpoint.
      */
-    public StatsHandler(String remoteEndpointID)
+    public StatsHandler(String originID, String remoteEndpointID)
     {
         this.remoteEndpointID = remoteEndpointID;
+        this.originID = originID;
     }
 
     @Override
@@ -311,7 +318,7 @@ public class StatsHandler
                 statsService,
                 conferenceName,
                 conferenceIDPrefix,
-                DEFAULT_JIGASI_ID,
+                DEFAULT_JIGASI_ID + "-" + originID,
                 this.remoteEndpointID);
         cpr.start();
 


### PR DESCRIPTION
Multiple calls in a conference were seen as one participant in callstats.io.