### PR TITLE
Adds a global property to disable sip reinvites on focus changed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
-    <jitsi-desktop.version>2.13.00e988e</jitsi-desktop.version>
+    <jitsi-desktop.version>2.13.1f9891e</jitsi-desktop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.26</slf4j.version>
     <smack.version>4.2.4-47d17fc</smack.version>


### PR DESCRIPTION
net.java.sip.communicator.impl.protocol.sip
.SKIP_REINVITE_ON_FOCUS_CHANGE_PROP, by default it is false.