### PR TITLE
Move version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -30,7 +30,7 @@
     <property name="debian.target.dir" value="release/jigasi" />
 
 
-    <condition property="label" value="build.SVN">
+    <condition property="label" value="build.GIT">
         <not>
             <isset property="label"/>
         </not>
@@ -67,7 +67,7 @@
         </delete>
     </target>
 
-    <target name="compile">
+    <target name="compile" depends="version">
         <mkdir dir="${output}" />
         <javac
             classpathref="compile.classpath"
@@ -312,7 +312,55 @@
         <replace file="${debian.target.dir}/debian/changelog"
                  token="_DATE_" value="${date}"/>
         <replace file="${debian.target.dir}/debian/changelog"
-                 token="_VERSION_" value="${label}"/>
+                 token="_VERSION_" value="${label}-1"/>
+    </target>
+    <!-- Jigasi Version -->
+    <target name="version">
+        <!-- extracts major version -->
+        <loadresource property="version.major">
+            <propertyresource name="label"/>
+            <filterchain>
+                <tokenfilter>
+                    <filetokenizer/>
+                    <replaceregex pattern="\..*\-.*" replace="" />
+                </tokenfilter>
+            </filterchain>
+        </loadresource>
+        <!-- extracts minor version -->
+        <loadresource property="version.minor">
+            <propertyresource name="label"/>
+            <filterchain>
+                <tokenfilter>
+                    <filetokenizer/>
+                    <replaceregex pattern="\d*\." replace="" />
+                    <replaceregex pattern="-\d*" replace="" />
+                </tokenfilter>
+            </filterchain>
+        </loadresource>
+        <!-- extracts build id -->
+        <loadresource property="version.buildid">
+            <propertyresource name="label"/>
+            <filterchain>
+                <tokenfilter>
+                    <filetokenizer/>
+                    <replaceregex pattern=".*\-" replace="" />
+                </tokenfilter>
+            </filterchain>
+        </loadresource>
+
+        <!-- set the build id according to the properties -->
+        <replaceregexp file="${src}/org/jitsi/jigasi/version/CurrentVersionImpl.java"
+                       match="VERSION_MAJOR = (.+)"
+                       replace="VERSION_MAJOR = ${version.major};"
+                       byline="true"/>
+        <replaceregexp file="${src}/org/jitsi/jigasi/version/CurrentVersionImpl.java"
+                       match="VERSION_MINOR = (.+)"
+                       replace="VERSION_MINOR = ${version.minor};"
+                       byline="true"/>
+        <replaceregexp file="${src}/org/jitsi/jigasi/version/CurrentVersionImpl.java"
+                       match="NIGHTLY_BUILD_ID = (.+)"
+                       replace="NIGHTLY_BUILD_ID = &quot;${version.buildid}&quot;;"
+                       byline="true"/>
     </target>
     <target name="copy-runtime-dependencies-from-maven">
         <delete failonerror="false" includeemptydirs="true">

--- a/pom.xml
+++ b/pom.xml
@@ -319,12 +319,6 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jitsi-version</artifactId>
-      <version>${jitsi-desktop.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
       <version>1.0-20190605.124131-5</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
-    <jitsi-desktop.version>2.13.1f9891e</jitsi-desktop.version>
+    <jitsi-desktop.version>2.13.cb5485e</jitsi-desktop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.26</slf4j.version>
     <smack.version>4.2.4-47d17fc</smack.version>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jicoco</artifactId>
-      <version>1.1-20190509.130302-15</version>
+      <version>1.1-1-ge7184ab</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -146,12 +146,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-utils</artifactId>
-      <version>1.0-20190401.122850-7</version>
+      <version>1.0-1-gaca0e20</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20190619.163300-386</version>
+      <version>1.0-0-gb3296cf</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -196,7 +196,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-stats</artifactId>
-      <version>1.0-20190606.142627-9</version>
+      <version>1.0-1-g944da7a</version>
     </dependency>
     <dependency>
       <!--

--- a/src/main/java/org/jitsi/jigasi/JigasiBundleActivator.java
+++ b/src/main/java/org/jitsi/jigasi/JigasiBundleActivator.java
@@ -18,13 +18,13 @@
 package org.jitsi.jigasi;
 
 import com.timgroup.statsd.*;
+import org.jitsi.meet.*;
 import org.jitsi.xmpp.extensions.*;
 import org.jitsi.xmpp.extensions.jibri.*;
 import org.jitsi.xmpp.extensions.jitsimeet.*;
 import org.jitsi.xmpp.extensions.rayo.*;
 import net.java.sip.communicator.service.gui.*;
 import net.java.sip.communicator.service.protocol.*;
-import net.java.sip.communicator.service.shutdown.*;
 import net.java.sip.communicator.util.*;
 import org.jitsi.jigasi.health.*;
 import org.jitsi.jigasi.stats.*;
@@ -320,10 +320,14 @@ public class JigasiBundleActivator
         {
             gateways.forEach(AbstractGateway::stop);
 
+            // Note that there are two ShutdownService implementations. One in
+            // jitsi coming from the ui-service bundle, and one is jicoco. We
+            // only use the one in jicoco because the other one is essentially
+            // a no-op.
             ShutdownService shutdownService
                 = ServiceUtils.getService(
-                osgiContext,
-                ShutdownService.class);
+                    osgiContext,
+                    ShutdownService.class);
 
             logger.info("Jigasi is shutting down NOW");
             shutdownService.beginShutdown();

--- a/src/main/java/org/jitsi/jigasi/osgi/JigasiBundleConfig.java
+++ b/src/main/java/org/jitsi/jigasi/osgi/JigasiBundleConfig.java
@@ -128,7 +128,7 @@ public class JigasiBundleConfig
                 "net/java/sip/communicator/impl/certificate/CertificateVerificationActivator"
             },
             {
-                "net/java/sip/communicator/impl/version/VersionActivator"
+                "org/jitsi/jigasi/version/VersionActivator"
             },
             {
                 "net/java/sip/communicator/service/protocol/ProtocolProviderActivator"

--- a/src/main/java/org/jitsi/jigasi/version/CurrentVersionImpl.java
+++ b/src/main/java/org/jitsi/jigasi/version/CurrentVersionImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright @ 2019 - present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jigasi.version;
+
+import org.jitsi.utils.version.*;
+
+/**
+ * Keeps constants for the application version.
+ *
+ * Note that the constants are modified at build time, so changes to this file
+ * must be synchronized with the build system.
+ *
+ * @author Boris Grozev
+ */
+public class CurrentVersionImpl
+{
+    /**
+     * The major version.
+     */
+    public static final int VERSION_MAJOR = 1;
+
+    /**
+     * The minor version.
+     */
+    public static final int VERSION_MINOR = 0;
+
+    /**
+     * The version prerelease ID of the current application version.
+     */
+    public static final String PRE_RELEASE_ID = null;
+
+    /**
+     * The nightly build ID. This file is auto-updated by build.xml.
+     */
+    public static final String NIGHTLY_BUILD_ID = "build.SVN";
+
+    static final Version VERSION
+            = new VersionImpl(
+            "Jigasi",
+            VERSION_MAJOR,
+            VERSION_MINOR,
+            NIGHTLY_BUILD_ID,
+            PRE_RELEASE_ID);
+}

--- a/src/main/java/org/jitsi/jigasi/version/VersionActivator.java
+++ b/src/main/java/org/jitsi/jigasi/version/VersionActivator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright @ 2019 - present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jigasi.version;
+
+import org.jitsi.utils.version.*;
+import org.jitsi.version.*;
+
+/**
+ * Extends {@link AbstractVersionActivator} in order to provider the
+ * {@code VersionService} implementation for the Jicofo.
+ *
+ * @author Boris Grozev
+ */
+public class VersionActivator
+        extends AbstractVersionActivator
+{
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Version getCurrentVersion()
+    {
+        return CurrentVersionImpl.VERSION;
+    }
+}


### PR DESCRIPTION
This adapts to the move of Version to jitsi-utils and uses its own implementation of a VersionService (extending the one in jicoco) instead of the one from jitsi-version. 

This will make jigasi identify itself as "Jigasi" to callstats.