### PR TITLE
Allows reconnecting the XMPP part of the call in case of network errors.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/CallContext.java
+++ b/src/main/java/org/jitsi/jigasi/CallContext.java
@@ -296,7 +296,7 @@ public class CallContext
      * Updates call resource based on timestamp, domain and if available and
      * the subdomain.
      */
-    private void updateCallResource()
+    void updateCallResource()
     {
         if (this.domain != null)
         {

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -278,6 +278,12 @@ public class JvbConference
     private boolean connFailedStatsSent = false;
 
     /**
+     * Whether we had send indication that XMPP connection terminated and
+     * the gateway session waiting for new XMPP call to be connected.
+     */
+    private boolean gwSesisonWaitingStatsSent = false;
+
+    /**
      * Creates new instance of <tt>JvbConference</tt>
      * @param gatewaySession the <tt>AbstractGatewaySession</tt> that will be
      *                       using this <tt>JvbConference</tt>.
@@ -766,6 +772,12 @@ public class JvbConference
             {
                 logger.info(this.callContext
                     + " Proceed with gwSession call on xmpp call hangup.");
+
+                if (!gwSesisonWaitingStatsSent)
+                {
+                    Statistics.incrementTotalCallsWithSipCallWaiting();
+                    gwSesisonWaitingStatsSent = true;
+                }
             }
         }
     }

--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -246,6 +246,12 @@ public class SipGatewaySession
     private SipCallKeepAliveTransformer transformerMonitor;
 
     /**
+     * Whether we had send indication that XMPP connection terminated and
+     * the gateway session was connected to a new XMPP call.
+     */
+    private boolean callReconnectedStatsSent = false;
+
+    /**
      * Creates new <tt>SipGatewaySession</tt> for given <tt>callResource</tt>
      * and <tt>sipCall</tt>. We already have SIP call instance, so this session
      * can be considered "incoming" SIP session(was created after incoming call
@@ -464,6 +470,12 @@ public class SipGatewaySession
                 jvbConferenceCall.setConference(sipCall.getConference());
 
                 CallManager.acceptCall(jvbConferenceCall);
+
+                if (!callReconnectedStatsSent)
+                {
+                    Statistics.incrementTotalCallsWithSipCallReconnected();
+                    callReconnectedStatsSent = true;
+                }
 
                 return null;
             }

--- a/src/main/java/org/jitsi/jigasi/stats/Statistics.java
+++ b/src/main/java/org/jitsi/jigasi/stats/Statistics.java
@@ -66,6 +66,23 @@ public class Statistics
         = "total_calls_with_connection_failed";
 
     /**
+     * The name of the number of conferences for which XMPP call was ended
+     * and the gateway part is waiting for new connection.
+     * {@code Integer}.
+     */
+    public static final String TOTAL_CALLS_WITH_SIP_CALL_WAITING
+        = "total_calls_with_sip_call_waiting";
+
+    /**
+     * The name of the number of conferences for which XMPP call was ended
+     * and the gateway part was waiting for new connection and the call was
+     * connected to new XMPP calls.
+     * {@code Integer}.
+     */
+    public static final String TOTAL_CALLS_WITH_SIP_CALL_RECONNECTED
+        = "total_calls_with_sip_call_reconnected";
+
+    /**
      * Total number of participants since started.
      */
     private static int totalParticipantsCount = 0;
@@ -85,6 +102,21 @@ public class Statistics
      * Total number of calls with xmpp connection failed since started.
      */
     private static AtomicLong totalCallsWithConnectionFailedCount
+        = new AtomicLong();
+
+    /**
+     * Total number of calls with xmpp call terminated and sip call waiting
+     * for new xmpp call.
+     */
+    private static AtomicLong totalCallsWithSipCallWaiting
+        = new AtomicLong();
+
+    /**
+     * Total number of calls with xmpp call terminated and sip call waiting
+     * for new xmpp call and new xmpp call and both calls were connected
+     * and operational.
+     */
+    private static AtomicLong totalCallsWithSipCalReconnected
         = new AtomicLong();
 
     /**
@@ -143,7 +175,10 @@ public class Statistics
             totalCallsWithMediaDroppedCount.get());
         stats.put(TOTAL_CALLS_WITH_CONNECTION_FAILED,
             totalCallsWithConnectionFailedCount.get());
-
+        stats.put(TOTAL_CALLS_WITH_SIP_CALL_WAITING,
+            totalCallsWithSipCallWaiting.get());
+        stats.put(TOTAL_CALLS_WITH_SIP_CALL_RECONNECTED,
+            totalCallsWithSipCalReconnected.get());
 
         stats.put(SHUTDOWN_IN_PROGRESS,
             JigasiBundleActivator.isShutdownInProgress());
@@ -247,6 +282,24 @@ public class Statistics
     public static void incrementTotalCallsWithConnectionFailed()
     {
         totalCallsWithConnectionFailedCount.incrementAndGet();
+    }
+
+    /**
+     * Increment the value of total number of calls with XMPP calls terminated
+     * and sip call waiting for new xmpp call to be connected.
+     */
+    public static void incrementTotalCallsWithSipCallWaiting()
+    {
+        totalCallsWithSipCallWaiting.incrementAndGet();
+    }
+
+    /**
+     * Increment the value of total number of calls with XMPP calls terminated
+     * and new XMPP call been connected again with the SIP call
+     */
+    public static void incrementTotalCallsWithSipCallReconnected()
+    {
+        totalCallsWithSipCalReconnected.incrementAndGet();
     }
 
     /**

--- a/src/main/java/org/jitsi/jigasi/stats/Statistics.java
+++ b/src/main/java/org/jitsi/jigasi/stats/Statistics.java
@@ -58,6 +58,14 @@ public class Statistics
         = Logger.getLogger(Statistics.class);
 
     /**
+     * The name of the number of conferences for which XMPP connection
+     * had failed.
+     * {@code Integer}.
+     */
+    public static final String TOTAL_CALLS_WITH_CONNECTION_FAILED
+        = "total_calls_with_connection_failed";
+
+    /**
      * Total number of participants since started.
      */
     private static int totalParticipantsCount = 0;
@@ -71,6 +79,12 @@ public class Statistics
      * Total number of calls with dropped media since started.
      */
     private static AtomicLong totalCallsWithMediaDroppedCount
+        = new AtomicLong();
+
+    /**
+     * Total number of calls with xmpp connection failed since started.
+     */
+    private static AtomicLong totalCallsWithConnectionFailedCount
         = new AtomicLong();
 
     /**
@@ -127,6 +141,8 @@ public class Statistics
         stats.put(TOTAL_CONFERENCE_SECONDS, cumulativeConferenceSeconds);
         stats.put(TOTAL_CALLS_WITH_DROPPED_MEDIA,
             totalCallsWithMediaDroppedCount.get());
+        stats.put(TOTAL_CALLS_WITH_CONNECTION_FAILED,
+            totalCallsWithConnectionFailedCount.get());
 
 
         stats.put(SHUTDOWN_IN_PROGRESS,
@@ -223,6 +239,14 @@ public class Statistics
     public static void incrementTotalCallsWithMediaDropped()
     {
         totalCallsWithMediaDroppedCount.incrementAndGet();
+    }
+
+    /**
+     * Increment the value of total number of calls with XMPP connection failed.
+     */
+    public static void incrementTotalCallsWithConnectionFailed()
+    {
+        totalCallsWithConnectionFailedCount.incrementAndGet();
     }
 
     /**


### PR DESCRIPTION
Throws stat when the XMPP part of the call receives connection failed
event. On connection fail the jingle call will be closed and room will
be left, waiting for connection to reconnect. When the connection
reconnects we join the room and new jingle call is established connected
 to the sip one. When jingle call is hangup the invite timeout is
 scheduled so this state of waiting to reconnect will finish either
 successfully or when timeout is reached.