### PR TITLE
Fixes a deadlock where stop and JvbConfStopTimer sync in different order

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1459,23 +1459,23 @@ public class JvbConference
                 try
                 {
                     syncRoot.wait(timeout);
-
-                    if (willCauseTimeout)
-                    {
-                        logger.error(callContext + " "
-                            + errorLog + " (" + timeout + " ms)");
-
-                        JvbConference.this.endReason = this.endReason;
-                        JvbConference.this.endReasonCode
-                            = OperationSetBasicTelephony.HANGUP_REASON_TIMEOUT;
-
-                        stop();
-                    }
                 }
                 catch (InterruptedException e)
                 {
                     Thread.currentThread().interrupt();
                 }
+            }
+
+            if (willCauseTimeout)
+            {
+                logger.error(callContext + " "
+                    + errorLog + " (" + timeout + " ms)");
+
+                JvbConference.this.endReason = this.endReason;
+                JvbConference.this.endReasonCode
+                    = OperationSetBasicTelephony.HANGUP_REASON_TIMEOUT;
+
+                stop();
             }
         }
 


### PR DESCRIPTION
Found one Java-level deadlock:
=============================
"JvbInviteTimeout":
  waiting to lock monitor 0x00007f014025f8b8 (object 0x000000070107ace8, a java.lang.Object),
  which is held by "pool-13-thread-1"
"pool-13-thread-1":
  waiting to lock monitor 0x00007f014025fcd8 (object 0x0000000701074568, a java.lang.Object),
  which is held by "JvbInviteTimeout"

Java stack information for the threads listed above:
===================================================
"JvbInviteTimeout":
	at org.jitsi.jigasi.JvbConference.setJvbCall(JvbConference.java:1396)
	- waiting to lock <0x000000070107ace8> (a java.lang.Object)
	at org.jitsi.jigasi.JvbConference.stop(JvbConference.java:514)
	- locked <0x00000007010746a8> (a org.jitsi.jigasi.JvbConference)
	at org.jitsi.jigasi.JvbConference$JvbConferenceStopTimeout.run(JvbConference.java:1472)
	- locked <0x0000000701074568> (a java.lang.Object)
	at java.lang.Thread.run(Thread.java:748)
"pool-13-thread-1":
	at org.jitsi.jigasi.JvbConference$JvbConferenceStopTimeout.cancel(JvbConference.java:1484)
	- waiting to lock <0x0000000701074568> (a java.lang.Object)
	at org.jitsi.jigasi.JvbConference$JvbConferenceStopTimeout.maybeScheduleInviteTimeout(JvbConference.java:1526)
	- locked <0x000000070107ace8> (a java.lang.Object)
	at org.jitsi.jigasi.JvbConference.setJvbCall(JvbConference.java:1400)
	- locked <0x000000070107ace8> (a java.lang.Object)
	at org.jitsi.jigasi.JvbConference.onJvbCallEnded(JvbConference.java:795)
	at org.jitsi.jigasi.JvbConference.access$1200(JvbConference.java:61)
	at org.jitsi.jigasi.JvbConference$JvbCallChangeListener.callStateChanged(JvbConference.java:1126)
	- locked <0x000000070107acf8> (a org.jitsi.jigasi.JvbConference$JvbCallChangeListener)
	at net.java.sip.communicator.service.protocol.Call.fireCallChangeEvent(Call.java:362)
	at net.java.sip.communicator.service.protocol.Call.setCallState(Call.java:408)
	at net.java.sip.communicator.service.protocol.media.MediaAwareCall.setCallState(MediaAwareCall.java:834)
	at net.java.sip.communicator.service.protocol.media.MediaAwareCall.removeCallPeer(MediaAwareCall.java:222)
	at net.java.sip.communicator.service.protocol.media.MediaAwareCall.peerStateChanged(MediaAwareCall.java:283)
	at net.java.sip.communicator.service.protocol.AbstractCallPeer.fireCallPeerChangeEvent(AbstractCallPeer.java:428)
	at net.java.sip.communicator.service.protocol.AbstractCallPeer.setState(AbstractCallPeer.java:959)
	at net.java.sip.communicator.service.protocol.media.MediaAwareCallPeer.setState(MediaAwareCallPeer.java:1062)
	- locked <0x000000070107c0e0> (a net.java.sip.communicator.impl.protocol.jabber.CallPeerMediaHandlerJabberImpl)
	at net.java.sip.communicator.impl.protocol.jabber.CallPeerJabberImpl.setState(CallPeerJabberImpl.java:1514)
	at net.java.sip.communicator.service.protocol.AbstractCallPeer.setState(AbstractCallPeer.java:931)
	at net.java.sip.communicator.impl.protocol.jabber.CallPeerJabberImpl.hangup(CallPeerJabberImpl.java:315)
	at net.java.sip.communicator.impl.protocol.jabber.OperationSetBasicTelephonyJabberImpl.hangupCallPeer(OperationSetBasicTelephonyJabberImpl.java:756)
	at org.jitsi.jigasi.CallManager$HangupCallThread.run(CallManager.java:575)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

Found 1 deadlock.