### PR TITLE
Skips reconnecting removed providers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
-    <jitsi-desktop.version>2.13.2ef5817</jitsi-desktop.version>
+    <jitsi-desktop.version>2.13.c920e8c</jitsi-desktop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.26</slf4j.version>
     <smack.version>4.2.4-47d17fc</smack.version>


### PR DESCRIPTION
If connection failed event and removing an account happen at the same
time, the thread for unregister&reconnect can put a PP instance in
currentlyReconnecting, while the provider is removed and we no longer
need to reconnect it.