### PR TITLE
Reconnect update

### DIFF
--- a/jigasi-home/sip-communicator.properties
+++ b/jigasi-home/sip-communicator.properties
@@ -73,6 +73,7 @@ org.jitsi.jigasi.xmpp.acc.IS_SERVER_OVERRIDDEN=true
 org.jitsi.jigasi.xmpp.acc.SERVER_ADDRESS=127.0.0.1
 org.jitsi.jigasi.xmpp.acc.VIDEO_CALLING_DISABLED=true
 org.jitsi.jigasi.xmpp.acc.JINGLE_NODES_ENABLED=false
+org.jitsi.jigasi.xmpp.acc.AUTO_DISCOVER_STUN=false
 org.jitsi.jigasi.xmpp.acc.IM_DISABLED=true
 org.jitsi.jigasi.xmpp.acc.SERVER_STORED_INFO_DISABLED=true
 org.jitsi.jigasi.xmpp.acc.IS_FILE_TRANSFER_DISABLED=true

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
-    <jitsi-desktop.version>2.13.41a063d</jitsi-desktop.version>
+    <jitsi-desktop.version>2.13.7fe22a7</jitsi-desktop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.26</slf4j.version>
     <smack.version>4.2.4-47d17fc</smack.version>

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -255,6 +255,11 @@ public class JvbConference
     private String jvbParticipantStatus = null;
 
     /**
+     * Synchronizes the write access to {@code jvbParticipantStatus}.
+     */
+    private final Object statusSync = new Object();
+
+    /**
      * Call hang up reason string that will be sent to the SIP peer.
      */
     private String endReason;
@@ -789,11 +794,16 @@ public class JvbConference
         }
     }
 
-    synchronized void setPresenceStatus(String statusMsg)
+    void setPresenceStatus(String statusMsg)
     {
-        if (statusMsg.equals(jvbParticipantStatus))
+        synchronized(statusSync)
         {
-            return;
+            if (statusMsg.equals(jvbParticipantStatus))
+            {
+                return;
+            }
+
+            jvbParticipantStatus = statusMsg;
         }
 
         if (mucRoom != null)
@@ -804,8 +814,6 @@ public class JvbConference
                     OperationSetJitsiMeetTools.class);
 
             jitsiMeetTools.setPresenceStatus(mucRoom, statusMsg);
-
-            jvbParticipantStatus = statusMsg;
         }
     }
 

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1518,6 +1518,9 @@ public class JvbConference
                     = OperationSetBasicTelephony.HANGUP_REASON_TIMEOUT;
 
                 stop();
+
+                timeoutThread = null;
+                logger.debug("Timeout thread is done " + this);
             }
         }
 
@@ -1533,17 +1536,6 @@ public class JvbConference
                 logger.debug("Trying to cancel " + this);
 
                 syncRoot.notifyAll();
-            }
-
-            try
-            {
-                timeoutThread.join();
-
-                timeoutThread = null;
-            }
-            catch (InterruptedException e)
-            {
-                Thread.currentThread().interrupt();
             }
 
             logger.debug("Canceled " + this);

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -494,17 +494,12 @@ public class JvbConference
 
         if (jvbCall != null)
         {
-            CallManager.hangupCall(jvbCall);
+            CallManager.hangupCall(jvbCall, true);
         }
 
         if (xmppProvider != null)
         {
             xmppProvider.removeRegistrationStateChangeListener(this);
-
-            logger.info(
-                callContext + " Removing account " + xmppAccount);
-
-            xmppProviderFactory.unloadAccount(xmppAccount);
 
             xmppProviderFactory = null;
 

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1221,7 +1221,7 @@ public class JvbConference
                 //     ProtocolProviderFactory#loadAccount()
                 //
                 // method can't (and doesn't) work, at least not without
-                // changing the implementation of the loadAccount method..
+                // changing the implementation of the loadAccount method.
                 //
                 // To avoid to have to store the dynamic accounts in the
                 // configuration and, consequently, to have to manage them, to
@@ -1239,6 +1239,10 @@ public class JvbConference
                 // account and there we can alter the connection credentials.
 
                 this.xmppPassword = value;
+                // add password in props so it is available
+                // for the UIServiceStub and getAccountID().getPassword()
+                // used on reconnect
+                properties.put(ProtocolProviderFactory.PASSWORD, value);
             }
             else if ("org.jitsi.jigasi.xmpp.acc.BOSH_URL_PATTERN"
                         .equals(overridenProp))

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -576,7 +576,7 @@ public class JvbConference
                 ((ProtocolProviderServiceJabberImpl) xmppProvider)
                     .getConnection() instanceof XMPPBOSHConnection)
             {
-                Object sessionId = getConnSessionId(
+                Object sessionId = Util.getConnSessionId(
                     ((ProtocolProviderServiceJabberImpl) xmppProvider)
                         .getConnection());
                 if (sessionId != null)
@@ -1577,59 +1577,6 @@ public class JvbConference
                 + endReason + ","
                 + errorLog + "]@"
                 + hashCode();
-        }
-    }
-
-    /**
-     * Extracts bosh connection sessionId, we just print it for debug
-     * purposes.
-     * @param connection the bosh connection which sessionId we will try to
-     * extract.
-     * @return the sessionId if extracted or null.
-     */
-    private static Object getConnSessionId(Object connection)
-    {
-        Field myField = getField(XMPPBOSHConnection.class, "sessionID");
-
-        if (myField != null)
-        {
-            myField.setAccessible(true);
-            try
-            {
-                return myField.get(connection);
-            }
-            catch( Exception e)
-            {
-                logger.error("cannot read it", e);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Utility method to get the field from a class.
-     * @param clazz the class.
-     * @param fieldName the field men.
-     * @return the field or null.
-     */
-    private static Field getField(Class clazz, String fieldName)
-    {
-        try
-        {
-            return clazz.getDeclaredField(fieldName);
-        }
-        catch (NoSuchFieldException e)
-        {
-            Class superClass = clazz.getSuperclass();
-            if (superClass == null)
-            {
-                return null;
-            }
-            else
-            {
-                return getField(superClass, fieldName);
-            }
         }
     }
 }

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -588,7 +588,7 @@ public class JvbConference
         }
         else if (evt.getNewState() == RegistrationState.UNREGISTERED)
         {
-            logger.error(this.callContext + " Unregistered XMPP.");
+            logger.error(this.callContext + " Unregistered XMPP:" + evt);
         }
         else if (evt.getNewState() == RegistrationState.REGISTERING)
         {

--- a/src/main/java/org/jitsi/jigasi/Main.java
+++ b/src/main/java/org/jitsi/jigasi/Main.java
@@ -268,6 +268,12 @@ public class Main
         System.setProperty(ConfigurationActivator.PNAME_USE_PROPFILE_CONFIG,
             "true");
 
+        // reported to drop calls on asterisk, as it does not reply
+        // to our re-invites
+        System.setProperty("net.java.sip.communicator.impl.protocol.sip" +
+                ".SKIP_REINVITE_ON_FOCUS_CHANGE_PROP",
+            "true");
+
         // disable smack packages before loading smack
         disableSmackProviders();
 

--- a/src/main/java/org/jitsi/jigasi/Main.java
+++ b/src/main/java/org/jitsi/jigasi/Main.java
@@ -274,6 +274,8 @@ public class Main
                 ".SKIP_REINVITE_ON_FOCUS_CHANGE_PROP",
             "true");
 
+        SmackConfiguration.setDefaultReplyTimeout(15000);
+
         // disable smack packages before loading smack
         disableSmackProviders();
 

--- a/src/main/java/org/jitsi/jigasi/rest/HandlerImpl.java
+++ b/src/main/java/org/jitsi/jigasi/rest/HandlerImpl.java
@@ -354,6 +354,8 @@ public class HandlerImpl
         {
             status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
             reason = e.getMessage();
+
+            logger.error("Health check failed", e);
         }
 
         if (reason != null)

--- a/src/main/java/org/jitsi/jigasi/util/Util.java
+++ b/src/main/java/org/jitsi/jigasi/util/Util.java
@@ -1,7 +1,7 @@
 /*
  * Jigasi, the JItsi GAteway to SIP.
  *
- * Copyright @ 2015 Atlassian Pty Ltd
+ * Copyright @ 2018 - present 8x8, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,13 @@ import net.java.sip.communicator.util.*;
 import org.gagravarr.ogg.*;
 import org.gagravarr.opus.*;
 import org.jitsi.impl.neomedia.codec.*;
-import org.jitsi.impl.neomedia.rtp.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.service.neomedia.codec.*;
 import org.jitsi.service.neomedia.format.*;
 import org.jitsi.utils.*;
+import org.jivesoftware.smack.bosh.*;
 
+import java.lang.reflect.*;
 import java.util.*;
 
 import javax.xml.transform.*;
@@ -283,4 +284,55 @@ public class Util
         }
     }
 
+    /**
+     * Extracts bosh connection sessionId if possible.
+     * @param connection the bosh connection which sessionId we will try to
+     * extract.
+     * @return the sessionId if extracted or null.
+     */
+    public static Object getConnSessionId(Object connection)
+    {
+        Field myField = getField(XMPPBOSHConnection.class, "sessionID");
+
+        if (myField != null)
+        {
+            myField.setAccessible(true);
+            try
+            {
+                return myField.get(connection);
+            }
+            catch( Exception e)
+            {
+                Logger.getLogger(Util.class).error("cannot read it", e);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Utility method to get the field from a class.
+     * @param clazz the class.
+     * @param fieldName the field men.
+     * @return the field or null.
+     */
+    private static Field getField(Class clazz, String fieldName)
+    {
+        try
+        {
+            return clazz.getDeclaredField(fieldName);
+        }
+        catch (NoSuchFieldException e)
+        {
+            Class superClass = clazz.getSuperclass();
+            if (superClass == null)
+            {
+                return null;
+            }
+            else
+            {
+                return getField(superClass, fieldName);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR's goal was to minimize the synchronization in the reconnect logic, that we saw several times jigasi filing incoming calls because of some lock in the reconnect logic ... 
Needs updating the pom.xml after merging: https://github.com/jitsi/jitsi/pull/636 as this is the main change.
While testing several scenarios of reconnecting (restarting prosody and stopping in/out on port 443 on the server with iptables) fixed few other bugs like authenticated dynamic accounts not able reconnect.