### PR TITLE
Small fixes 

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -15,6 +15,9 @@ net.java.sip.communicator.impl.protocol.sip.level=SEVERE
 # Do not worry about missing strings
 net.java.sip.communicator.service.resources.AbstractResourcesService.level=SEVERE
 
+# Does not print roster warning on account removals
+org.jivesoftware.smack.roster.Roster.level=SEVERE
+
 #net.java.sip.communicator.service.protocol.level=ALL
 
 # Syslog(uncomment handler to use)

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -835,10 +835,6 @@ public class JvbConference
             return;
         }
 
-        jvbCall.removeCallChangeListener(callChangeListener);
-        jvbCall.removeCallChangeListener(statsHandler);
-        statsHandler = null;
-
         setJvbCall(null);
 
         if (started)
@@ -1435,6 +1431,14 @@ public class JvbConference
     {
         synchronized(jvbCallWriteSync)
         {
+            if (newJvbCall == null)
+            {
+                // cleanup
+                this.jvbCall.removeCallChangeListener(callChangeListener);
+                this.jvbCall.removeCallChangeListener(statsHandler);
+                statsHandler = null;
+            }
+
             this.jvbCall = newJvbCall;
 
             inviteTimeout.maybeScheduleInviteTimeout();

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -511,6 +511,15 @@ public class JvbConference
         {
             xmppProvider.removeRegistrationStateChangeListener(this);
 
+            // in case we were not able to create jvb call, unit tests case
+            if (jvbCall == null)
+            {
+                logger.info(
+                    callContext + " Removing account " + xmppAccount);
+
+                xmppProviderFactory.unloadAccount(xmppAccount);
+            }
+
             xmppProviderFactory = null;
 
             xmppAccount = null;

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1581,11 +1581,10 @@ public class JvbConference
         @Override
         public String toString()
         {
-            return "JvbConferenceStopTimeout["
-                + callContext + ","
-                + endReason + ","
-                + errorLog + "]@"
-                + hashCode();
+            return "JvbConferenceStopTimeout[ctx=" + callContext
+                + ", willCauseTimeout:" + willCauseTimeout
+                + (willCauseTimeout ? endReason + "," + errorLog: "")
+                + "]@"+ hashCode();
         }
     }
 }

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -586,9 +586,10 @@ public class JvbConference
             // Join the MUC
             joinConferenceRoom();
 
-            if (xmppProvider != null &&
-                ((ProtocolProviderServiceJabberImpl) xmppProvider)
-                    .getConnection() instanceof XMPPBOSHConnection)
+            if (xmppProvider != null
+                && xmppProvider instanceof ProtocolProviderServiceJabberImpl
+                && ((ProtocolProviderServiceJabberImpl) xmppProvider)
+                        .getConnection() instanceof XMPPBOSHConnection)
             {
                 Object sessionId = Util.getConnSessionId(
                     ((ProtocolProviderServiceJabberImpl) xmppProvider)


### PR DESCRIPTION
Small fixes found while examing logs of running latest jigasi release and running the tests.

The tests fail from time to time because of async establishing calls. We need a listener to be notified when xmpp call was established in order to fix them.