### PR TITLE
Updates jbosh to latest 0.9.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
       <version>${smack.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.igniterealtime.jbosh</groupId>
+      <artifactId>jbosh</artifactId>
+      <version>0.9.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-tcp</artifactId>
       <version>${smack.version}</version>


### PR DESCRIPTION
Fixes a lock we had seen where closing connection failed bosh connection
can cause a lock and then leak
https://github.com/igniterealtime/jbosh/pull/18