### PR TITLE
fix(JvbConference): NPE in setJvbCall

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1434,8 +1434,11 @@ public class JvbConference
             if (newJvbCall == null)
             {
                 // cleanup
-                this.jvbCall.removeCallChangeListener(callChangeListener);
-                this.jvbCall.removeCallChangeListener(statsHandler);
+                if (this.jvbCall != null)
+                {
+                    this.jvbCall.removeCallChangeListener(callChangeListener);
+                    this.jvbCall.removeCallChangeListener(statsHandler);
+                }
                 statsHandler = null;
             }
 


### PR DESCRIPTION
java.lang.NullPointerException
        at org.jitsi.jigasi.JvbConference.setJvbCall(JvbConference.java:1437)
        at org.jitsi.jigasi.JvbConference.stop(JvbConference.java:532)
        at org.jitsi.jigasi.TranscriptionGatewaySession.lambda$notifyChatRoomMemberUpdated$0(TranscriptionGatewaySession.java:339)
        at java.lang.Thread.run(Thread.java:748)