### PR TITLE
Clears participants instances on leave.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
@@ -368,7 +368,11 @@ public class Transcriber
      */
     public void participantLeft(String identifier)
     {
-        Participant participant = getParticipant(identifier);
+        Participant participant;
+        synchronized (this.participants)
+        {
+            participant = this.participants.remove(identifier);
+        }
 
         if (participant != null)
         {


### PR DESCRIPTION
Checks whether we have transcriptions request is by checking the last presence for that transcribe request extension in all participants.
MultiUserChat and ChatRoomJabberImpl both use StanzaListener for incoming Presence packets. It can happen (depending of listener order) that we first get the left event from MultiUserChat and then get the chance to update last presence, which cannot update it as member had left.
As a result we will have a participant which is offline, but it is lastPresence will say available and requesting transcription.
By removing the participant we make sure we don't fall in this case.