### PR TITLE
Add optional sentry error tracking

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -1,6 +1,7 @@
 
 handlers= java.util.logging.ConsoleHandler
 #handlers= java.util.logging.ConsoleHandler, com.agafua.syslog.SyslogHandler
+#handlers= java.util.logging.ConsoleHandler, io.sentry.jul.SentryHandler
 
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
@@ -20,8 +21,11 @@ org.jivesoftware.smack.roster.Roster.level=SEVERE
 
 #net.java.sip.communicator.service.protocol.level=ALL
 
-# Syslog(uncomment handler to use)
+# Syslog (uncomment handler to use)
 com.agafua.syslog.SyslogHandler.transport = udp
 com.agafua.syslog.SyslogHandler.facility = local0
 com.agafua.syslog.SyslogHandler.port = 514
 com.agafua.syslog.SyslogHandler.hostname = localhost
+
+# Sentry (uncomment handler to use)
+io.sentry.jul.SentryHandler.level=WARNING

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry</artifactId>
+      <version>1.7.30</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20180130</version>


### PR DESCRIPTION
Because Jitsi is using `java.util.logging` it is quite easy to implement:
https://docs.sentry.io/clients/java/integrations/#javautillogging

To configure the Sentry client the SENTRY_DSN environment variable has to be set. But there are also some other possibilities.

The same changes for the other jitsi repositories can be found here:
- https://github.com/jitsi/jicofo/pull/449
- https://github.com/jitsi/jitsi-videobridge/pull/1152