### PR TITLE
feat(transcriptions): abort on quota limit reached

### DIFF
--- a/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
@@ -242,7 +242,7 @@ public class TranscriptionGatewaySession
         // The conference is over, make sure the transcriber stops
         if(!transcriber.finished())
         {
-            transcriber.stop();
+            transcriber.stop(null);
 
             for(TranscriptPublisher.Promise promise : finalTranscriptPromises)
             {
@@ -411,6 +411,13 @@ public class TranscriptionGatewaySession
         // to stop transcription before jigasi leaves conference
 //        sendMessageToRoom("The complete transcription can be " +
 //                "found at <insert_link_here>");
+    }
+
+    @Override
+    public void failed(FailureReason reason)
+    {
+        // Leave the conference room
+        this.jvbConference.stop();
     }
 
     @Override

--- a/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
@@ -1009,7 +1009,20 @@ public class GoogleCloudTranscriptionService
         public void onError(Throwable t)
         {
             logger.warn(debugName + ": received an error from the Google Cloud API", t);
-            requestManager.terminateCurrentSession();
+
+            if (t instanceof ResourceExhaustedException)
+            {
+                for (TranscriptionListener l : requestManager.getListeners())
+                {
+                    l.failed(TranscriptionListener.FailureReason.RESOURCES_EXHAUSTED);
+                }
+
+                requestManager.stop();
+            }
+            else
+            {
+                requestManager.terminateCurrentSession();
+            }
         }
 
         @Override

--- a/src/main/java/org/jitsi/jigasi/transcription/Participant.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Participant.java
@@ -559,6 +559,14 @@ public class Participant
         transcriber.checkIfFinishedUp();
     }
 
+    @Override
+    public void failed(FailureReason reason)
+    {
+        isCompleted = true;
+        logger.error(getDebugName() + " transcription failed: " + reason);
+        transcriber.stop(reason);
+    }
+
     /**
      * Get whether everything this participant said has been transcribed
      *

--- a/src/main/java/org/jitsi/jigasi/transcription/Transcript.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Transcript.java
@@ -144,6 +144,12 @@ public class Transcript
         // nothing do to
     }
 
+    @Override
+    public void failed(FailureReason reason)
+    {
+        // whatever
+    }
+
     /**
      * Notify the transcript that the conference started at this exact moment
      * Will be ignored if already told the conference started

--- a/src/main/java/org/jitsi/jigasi/transcription/TranscriptionListener.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/TranscriptionListener.java
@@ -38,4 +38,23 @@ public interface TranscriptionListener
      * the transcription has been completed
      */
     void completed();
+
+    /**
+     * Notify this listener that the transcriptions has failed and no new
+     * results will come in.
+     * @param reason the failure reason
+     */
+    void failed(FailureReason reason);
+
+    /**
+     * Passed as an argument to {@link #failed(FailureReason)}.
+     */
+    enum FailureReason
+    {
+        /**
+         * The request quota limit set by the transcription service provider
+         * has been exhausted.
+         */
+        RESOURCES_EXHAUSTED
+    }
 }

--- a/src/main/java/org/jitsi/jigasi/transcription/TranslationManager.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/TranslationManager.java
@@ -186,4 +186,10 @@ public class TranslationManager
     {
         languages.clear();
     }
+
+    @Override
+    public void failed(FailureReason reason)
+    {
+        completed();
+    }
 }


### PR DESCRIPTION
Will stop the transcription session if the GoogleCloudTranscriptionService comes back with ResourceExhaustedException.

Will also increment failed_transcriber Datadog property on failure.