### PR TITLE
fix(xmpp): disable stream management and resume

### DIFF
--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
@@ -31,6 +31,7 @@ import org.jitsi.service.configuration.*;
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.iqrequest.*;
 import org.jivesoftware.smack.packet.*;
+import org.jivesoftware.smack.tcp.*;
 import org.jxmpp.jid.parts.*;
 import org.osgi.framework.*;
 
@@ -74,6 +75,14 @@ public class CallControlMucActivator
      */
     public static final String BREWERY_ENABLED_PROP
         = "org.jitsi.jigasi.BREWERY_ENABLED";
+
+    // Disable stream management as it could lead to unexpected behaviour,
+    // because we do not account for that to happen.
+    static
+    {
+        XMPPTCPConnection.setUseStreamManagementDefault(false);
+        XMPPTCPConnection.setUseStreamManagementResumptionDefault(false);
+    }
 
     /**
      * The call controlling logic.


### PR DESCRIPTION
The app is not expecting for that to happen also there is a known smack
issue which could lead to a deadlock:

https://discourse.igniterealtime.org/t/deadlock-between-the-reader-and-writer-with-stream-management/87442/3