### PR TITLE
feat(transcription): improve handling of buffer

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/Participant.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Participant.java
@@ -624,11 +624,11 @@ public class Participant
                    silenceFilter.giveSegment(audio);
                    if(silenceFilter.shouldFilter())
                    {
+                       buffer.clear();
                        return;
                    }
                    else if(silenceFilter.newSpeech())
                    {
-                       buffer.clear();
                        toBuffer = silenceFilter.getSpeechWindow();
                    }
                    else
@@ -647,7 +647,9 @@ public class Participant
                }
                catch (BufferOverflowException | ReadOnlyBufferException e)
                {
-                   sendRequest(audio);
+                   sendRequest(buffer.array());
+                   sendRequest(toBuffer);
+                   buffer.clear();
                }
 
                int spaceLeft = buffer.limit() - buffer.position();


### PR DESCRIPTION
Per the comments of Boris in #261 the `BufferOverflowException` was not handled properly.

The buffer is also cleared whenever a "silent" window is detected. I think it's equivalent to clearing the buffer whenever a new "speech" window is detected expect for the fact that there is not stale audio in memory, so it's a bit more efficient. 