### PR TITLE
Fix problem loading smack classes.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/Main.java
+++ b/src/main/java/org/jitsi/jigasi/Main.java
@@ -28,6 +28,7 @@ import org.jitsi.service.configuration.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.utils.*;
 import org.jivesoftware.smack.*;
+import org.jivesoftware.smack.tcp.*;
 
 /**
  * The gateway for Jitsi Videobridge conferences. Requires one SIP
@@ -275,6 +276,11 @@ public class Main
             "true");
 
         SmackConfiguration.setDefaultReplyTimeout(15000);
+
+        // Disable stream management as it could lead to unexpected behaviour,
+        // because we do not account for that to happen.
+        XMPPTCPConnection.setUseStreamManagementDefault(false);
+        XMPPTCPConnection.setUseStreamManagementResumptionDefault(false);
 
         // disable smack packages before loading smack
         disableSmackProviders();

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
@@ -76,14 +76,6 @@ public class CallControlMucActivator
     public static final String BREWERY_ENABLED_PROP
         = "org.jitsi.jigasi.BREWERY_ENABLED";
 
-    // Disable stream management as it could lead to unexpected behaviour,
-    // because we do not account for that to happen.
-    static
-    {
-        XMPPTCPConnection.setUseStreamManagementDefault(false);
-        XMPPTCPConnection.setUseStreamManagementResumptionDefault(false);
-    }
-
     /**
      * The call controlling logic.
      */


### PR DESCRIPTION
Seems that https://github.com/jitsi/jigasi/pull/258/commits/dfd269d33cb775b036649e6ef5cca9bf5ebd82d3 is not resolving the problem
and we still experience it.

While doing XMPPTCPConnection.setUseStreamManagementDefault we start
loading SmackInitialization class which waits for ProviderManager class
to be loaded but ProviderManager is waiting to load SmackInitialization.
Moving XMPPTCPConnection.setUseStreamManagementDefault in the main
thread will ensure we load SmackInitialization earlier and should fix
the problem.