### PR TITLE
fix: Clear listeners if we fail to join the room.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -917,12 +917,6 @@ public class JvbConference
             this.jitsiMeetTools = null;
         }
 
-        if (mucRoom == null)
-        {
-            logger.warn(this.callContext + " MUC room is null");
-            return;
-        }
-
         OperationSetIncomingDTMF opSet
             = this.xmppProvider.getOperationSet(OperationSetIncomingDTMF.class);
         if (opSet != null)
@@ -931,6 +925,12 @@ public class JvbConference
         OperationSetMultiUserChat muc
             = xmppProvider.getOperationSet(OperationSetMultiUserChat.class);
         muc.removePresenceListener(this);
+
+        if (mucRoom == null)
+        {
+            logger.warn(this.callContext + " MUC room is null");
+            return;
+        }
 
         mucRoom.leave();
 


### PR DESCRIPTION
In environment where jigasi cannot join room with password, fix to clear
 listeners on failing to join the room.