### PR TITLE
debian: don't depend on a specific JRE version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,13 @@ Section: net
 Priority: extra
 Maintainer: Jitsi Team <dev@jitsi.org>
 Uploaders: Emil Ivov <emcho@jitsi.org>, Damian Minkov <damencho@jitsi.org>
-Build-Depends: debhelper, dh-systemd, openjdk-8-jre-headless | openjdk-11-jre-headless, maven
+Build-Depends: debhelper, dh-systemd, java8-runtime-headless | java8-runtime | java11-runtime-headless | java11-runtime, maven
 Standards-Version: 3.9.3
 Homepage: https://jitsi.org
 
 Package: jigasi
 Architecture: any
-Depends: ${misc:Depends}, openjdk-8-jre-headless | openjdk-11-jre-headless, libxss1, openssl
+Depends: ${misc:Depends}, java8-runtime-headless | java8-runtime | java11-runtime-headless | java11-runtime, libxss1, openssl
 Description: Jitsi Gateway for SIP
  Jitsi Meet is a WebRTC JavaScript application that uses Jitsi
  Videobridge to provide high quality, scalable video conferences.


### PR DESCRIPTION
This makes it possible to use AdoptOpenJDK builds. This is useful for
running Java 8 on Debian Buster, for example.