### PR TITLE
Disable the pcap logging in default config

### DIFF
--- a/jigasi-home/sip-communicator.properties
+++ b/jigasi-home/sip-communicator.properties
@@ -15,7 +15,7 @@ net.java.sip.communicator.impl.protocol.SingleCallInProgressPolicy.enabled=false
 net.java.sip.communicator.impl.neomedia.codec.audio.opus.encoder.COMPLEXITY=10
 
 # Disables packet logging
-net.java.sip.communicator.packetlogging.PACKET_LOGGING_ENABLED=true
+net.java.sip.communicator.packetlogging.PACKET_LOGGING_ENABLED=false
 
 net.java.sip.communicator.impl.protocol.sip.acc1403273890647=acc1403273890647
 net.java.sip.communicator.impl.protocol.sip.acc1403273890647.ACCOUNT_UID=SIP\:<<JIGASI_SIPUSER>>


### PR DESCRIPTION
Only enable this if necessary to debug, but not in default install.
The comment even says it disables it, but in previous setting it would (obviously) enable it.