### PR TITLE
fix: Disable Smack providers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
 
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
-    <jitsi-desktop.version>2.13.232116b40</jitsi-desktop.version>
+    <jitsi-desktop.version>2.13.8258aa5ae</jitsi-desktop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.26</slf4j.version>
-    <smack.version>4.2.4-47d17fc</smack.version>
+    <smack.version>4.2.4-4fa73bd</smack.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/jitsi/jigasi/Main.java
+++ b/src/main/java/org/jitsi/jigasi/Main.java
@@ -169,6 +169,7 @@ public class Main
             "org.jivesoftware.smackx.bytestreams",
             "org.jivesoftware.smackx.filetransfer",
             "org.jivesoftware.smackx.hoxt",
+            "org.jivesoftware.smackx.httpfileupload",
             "org.jivesoftware.smackx.si",
             "org.jivesoftware.smackx.vcardtemp",
             "org.jivesoftware.smackx.xhtmlim",
@@ -275,15 +276,15 @@ public class Main
                 ".SKIP_REINVITE_ON_FOCUS_CHANGE_PROP",
             "true");
 
+        // disable smack packages before loading smack
+        disableSmackProviders();
+
         SmackConfiguration.setDefaultReplyTimeout(15000);
 
         // Disable stream management as it could lead to unexpected behaviour,
         // because we do not account for that to happen.
         XMPPTCPConnection.setUseStreamManagementDefault(false);
         XMPPTCPConnection.setUseStreamManagementResumptionDefault(false);
-
-        // disable smack packages before loading smack
-        disableSmackProviders();
 
         ComponentMain main = new ComponentMain();
 


### PR DESCRIPTION
Disabling Smack providers should happen before any Smack class loading
to prevent global/static connection listeners attaching.
This was causing several disco-info been executed on joining room that
slows down the connection.
This brings another optimization in smack to avoid muc service discovery
 on every room joined, now it is done once every 24hours. https://github.com/jitsi/Smack/commit/4fa73bde03b27b9166809ca6c2e5ebafe7d844b7