### PR TITLE
fix: Fixes transcriber receiving conference member events.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-8-g340be56</version>
+      <version>1.0-12-gd6044ff</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -475,7 +475,7 @@
         <enabled>false</enabled>
       </snapshots>
       <url>
-        https://github.com/jitsi/jitsi-maven-repository/raw/master/releases/
+        https://raw.github.com/jitsi/jitsi-maven-repository/master/releases/
       </url>
     </repository>
     <repository>
@@ -489,7 +489,7 @@
         <enabled>true</enabled>
       </snapshots>
       <url>
-        https://github.com/jitsi/jitsi-maven-repository/raw/master/snapshots/
+        https://raw.github.com/jitsi/jitsi-maven-repository/master/snapshots/
       </url>
     </repository>
   </repositories>

--- a/src/main/java/org/jitsi/jigasi/JigasiBundleActivator.java
+++ b/src/main/java/org/jitsi/jigasi/JigasiBundleActivator.java
@@ -245,9 +245,6 @@ public class JigasiBundleActivator
             logger.info("skipped initialization of TranscriptionGateway");
         }
 
-        // Register Jitsi Meet media presence extension.
-        MediaPresenceExtension.registerExtensions();
-
         // Register Rayo IQs
         new RayoIqProvider().registerRayoIQs();
 


### PR DESCRIPTION
The MediaPresenceExtension was getting overridden and some parts of the
jingle were not parsed.
The extension was a duplicate of SourcePacketExtension, so we got
removed it and started using the common one.
https://github.com/jitsi/jitsi/pull/696