### PR TITLE
GoogleCloudTranscription: save unchanged transcripts if they are final

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
@@ -1003,7 +1003,8 @@ public class GoogleCloudTranscriptionService
             SpeechRecognitionAlternative alternative = result.getAlternatives(0);
             String newTranscript = alternative.getTranscript();
 
-            if (this.latestTranscript.equals(newTranscript))
+            if (this.latestTranscript.equals(newTranscript) &&
+                (!result.getIsFinal() || newTranscript.length() == 0))
             {
                 if  (logger.isDebugEnabled())
                 {


### PR DESCRIPTION
Currently final transcripts are discarded when unchanged from latest text,
which means they do not make it to the remote POST URL or to the final
saved transcript file.