### PR TITLE
Added config option for google cloud langauge

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/AbstractTranscriptPublisher.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/AbstractTranscriptPublisher.java
@@ -105,6 +105,16 @@ public abstract class AbstractTranscriptPublisher<T>
         = "org.jitsi.jigasi.transcription.SCRIPTS_TO_EXECUTE_LIST";
 
     /**
+     * The property name for Default google cloud speech to text model to use
+     * Set config value in format org.jitsi.jigasi.transcription.LANG_CODE=en-US 
+     * inside config file sip-communicator.properties 
+     * {@link this#P_TRANSCRIPTION_LANGUAGE_VALUE}
+     */
+    public final static String P_TRANSCRIPTION_LANGUAGE_VALUE
+        = "org.jitsi.jigasi.transcription.LANG_CODE";
+
+
+    /**
      * The default for the url
      */
     public final static String TRANSCRIPT_BASE_URL_DEFAULT_VALUE
@@ -116,6 +126,7 @@ public abstract class AbstractTranscriptPublisher<T>
      */
     public final static String TRANSCRIPT_DIRECTORY_DEFAULT_VALUE
         = "/var/lib/jigasi/transcripts";
+
 
     /**
      * By default do not advertise the URL
@@ -131,6 +142,13 @@ public abstract class AbstractTranscriptPublisher<T>
      * By default when recording audio the format to store it as is WAV
      */
     public final static String RECORD_AUDIO_FORMAT_DEFAULT_VALUE = "wav";
+    
+    /**
+     * By default Google Speech to text will use this language model if not
+     * no value set in sip-communicator.properties config file
+     */
+    public final static String TRANSCRIPTION_LANGUAGE_DEFAULT_VALUE = "en-US";
+
 
     /**
      * By default do not execute scripts
@@ -393,6 +411,18 @@ public abstract class AbstractTranscriptPublisher<T>
         return JigasiBundleActivator.getConfigurationService()
             .getString(P_NAME_RECORD_AUDIO_FORMAT,
                 RECORD_AUDIO_FORMAT_DEFAULT_VALUE);
+    }
+
+    /**
+     * Get in default transcription language model to use for speech to text
+     *
+     * @return language model to use e.g. en-US 
+     */
+    public static String getTranscriptionLanguageValue()
+    {
+        return JigasiBundleActivator.getConfigurationService()
+            .getString(P_TRANSCRIPTION_LANGUAGE_VALUE,
+            TRANSCRIPTION_LANGUAGE_DEFAULT_VALUE);
     }
 
     /**

--- a/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
@@ -166,6 +166,11 @@ public class GoogleCloudTranscriptionService
     private final static boolean RETRIEVE_INTERIM_RESULTS = true;
 
     /**
+     * Whether the Google cloud API automatic punctuation option is set 
+     */
+    private final static boolean AUTOMATIC_PUNCTUATION_OPTION = true;
+
+    /**
      * Whether the Google Cloud API only listens for a single utterance
      * or continuous to listen once an utterance is over
      */
@@ -267,9 +272,12 @@ public class GoogleCloudTranscriptionService
         }
 
         // set the Language tag
-        String languageTag = request.getLocale().toLanguageTag();
+        String languageTag =  AbstractTranscriptPublisher.getTranscriptionLanguageValue() ;
         validateLanguageTag(languageTag);
         builder.setLanguageCode(languageTag);
+
+        // Add Automatic Punctuation option in Google cloud speech to text api
+        builder.setEnableAutomaticPunctuation(AUTOMATIC_PUNCTUATION_OPTION);
 
         addSpeechContexts(builder);
 


### PR DESCRIPTION
This commit adds support for changing default transcription language code using config variable
org.jitsi.jigasi.transcription.LANG_CODE=en-US inside file sip-communicator.properties