### PR TITLE
Fix typo on comments and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Using Jigasi to transcribe a Jitsi Meet conference
 It is also possible to use Jigasi as a provider of nearly real-time transcription
 while a conference is ongoing as well as serving a complete transcription
 after the conference is over. This can be done by using the SIP dial button and 
-using the the URI `jitsi_meet_transcribe`. 
+using the URI `jitsi_meet_transcribe`. 
 Currently Jigasi can send speech-to-text results to
 the chat of a Jitsi Meet room as either plain text or JSON. If it's send in JSON,
 Jitsi Meet will provide subtitles in the left corner of the video, while plain text

--- a/src/main/java/org/jitsi/jigasi/transcription/LocalJsonTranscriptHandler.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/LocalJsonTranscriptHandler.java
@@ -97,7 +97,7 @@ public class LocalJsonTranscriptHandler
     // "event" JSON object fields
 
     /**
-     * This fields stores the the type of event. Can be
+     * This fields stores the type of event. Can be
      * {@link Transcript.TranscriptEventType#JOIN},
      * {@link Transcript.TranscriptEventType#LEAVE},
      * {@link Transcript.TranscriptEventType#RAISE_HAND} or
@@ -111,7 +111,7 @@ public class LocalJsonTranscriptHandler
     public final static String JSON_KEY_EVENT_TIMESTAMP = "timestamp";
 
     /**
-     * This field stores the  the participant who caused the event as
+     * This field stores the participant who caused the event as
      * a Participant object
      */
     public final static String JSON_KEY_EVENT_PARTICIPANT = "participant";


### PR DESCRIPTION
`s/the /the the /g`