### PR TITLE
fix: Updates around lobby and outgoing calls.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/AbstractGateway.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGateway.java
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jigasi;
 
+import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.util.*;
 import org.jxmpp.jid.*;
 import org.osgi.framework.*;
@@ -156,6 +157,10 @@ public abstract class AbstractGateway<T extends AbstractGatewaySession>
 
         fireGatewaySessionAdded(source);
     }
+
+    @Override
+    public void onLobbyWaitReview(ChatRoom lobbyRoom)
+    {}
 
     /**
      * Finds {@link AbstractGatewaySession} for given <tt>callResource</tt> if

--- a/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
@@ -17,7 +17,6 @@
  */
 package org.jitsi.jigasi;
 
-import org.jitsi.xmpp.extensions.jibri.*;
 import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.event.*;
 import org.jivesoftware.smack.packet.*;
@@ -272,6 +271,27 @@ public abstract class AbstractGatewaySession
         for (GatewaySessionListener listener : gwListeners)
         {
             listener.onJvbRoomJoined(this);
+        }
+    }
+
+    /**
+     * Method called by {@link Lobby} to notify session that it has
+     * joined the lobby room.
+     *
+     * This method Notifies {@link GatewaySessionListener}(if any) that we have
+     * just joined the lobby room(call is not started yet - just the MUC and we are waiting for a modrator to accept it)
+     */
+    public void notifyOnLobbyWaitReview(ChatRoom lobbyRoom)
+    {
+        Iterable<GatewaySessionListener> gwListeners;
+        synchronized (listeners)
+        {
+            gwListeners = new ArrayList<>(listeners);
+        }
+
+        for (GatewaySessionListener listener : gwListeners)
+        {
+            listener.onLobbyWaitReview(lobbyRoom);
         }
     }
 

--- a/src/main/java/org/jitsi/jigasi/GatewaySessionListener.java
+++ b/src/main/java/org/jitsi/jigasi/GatewaySessionListener.java
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jigasi;
 
+import net.java.sip.communicator.service.protocol.*;
 
 /**
  * Class used to listen for various {@link AbstractGatewaySession} state
@@ -34,4 +35,11 @@ public interface GatewaySessionListener<T extends AbstractGatewaySession>
      *               takes place.
      */
     void onJvbRoomJoined(T source);
+
+    /**
+     * Called when a <tt>AbstractGatewaySession</tt> has joined the lobby MUC
+     *
+     * @param lobbyRoom the {@link ChatRoom} representing the lobby room.
+     */
+    void onLobbyWaitReview(ChatRoom lobbyRoom);
 }

--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -29,7 +29,6 @@ import org.jitsi.utils.concurrent.*;
 import org.jitsi.utils.*;
 import org.jivesoftware.smack.packet.*;
 import org.json.simple.*;
-import org.jxmpp.jid.*;
 
 import java.io.*;
 import java.text.*;
@@ -1176,6 +1175,20 @@ public class SipGatewaySession
         if (soundNotificationManager != null)
         {
             soundNotificationManager.notifyJvbRoomJoined();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void notifyOnLobbyWaitReview(ChatRoom lobbyRoom)
+    {
+        super.notifyOnLobbyWaitReview(lobbyRoom);
+
+        if (soundNotificationManager != null)
+        {
+            soundNotificationManager.notifyLobbyWaitReview();
         }
     }
 

--- a/src/main/java/org/jitsi/jigasi/lobby/Lobby.java
+++ b/src/main/java/org/jitsi/jigasi/lobby/Lobby.java
@@ -133,8 +133,7 @@ public class Lobby
     {
         joinRoom(getRoomJid());
 
-        this.sipGatewaySession.getSoundNotificationManager()
-            .notifyLobbyWaitReview();
+        this.sipGatewaySession.notifyOnLobbyWaitReview(this.mucRoom);
     }
 
     /**
@@ -159,9 +158,7 @@ public class Lobby
 
         setupChatRoom(mucRoom);
 
-        Localpart resourceIdentifier = getResourceIdentifier();
-
-        mucRoom.joinAs(resourceIdentifier.toString());
+        mucRoom.joinAs(getResourceIdentifier().toString());
 
         this.mucRoom = mucRoom;
     }
@@ -391,9 +388,9 @@ public class Lobby
      *
      * @return <tt>Localpart</tt> identifier.
      */
-    public Localpart getResourceIdentifier()
+    public Resourcepart getResourceIdentifier()
     {
-        return this.roomJid.getLocalpartOrNull();
+        return this.roomJid.getResourceOrNull();
     }
 
     /**

--- a/src/test/java/org/jitsi/jigasi/GatewaySessionAsserts.java
+++ b/src/test/java/org/jitsi/jigasi/GatewaySessionAsserts.java
@@ -39,6 +39,10 @@ public class GatewaySessionAsserts
         }
     }
 
+    @Override
+    public void onLobbyWaitReview(ChatRoom lobbyRoom)
+    {}
+
     public void assertJvbRoomJoined(AbstractGatewaySession session, long timeout)
         throws InterruptedException
     {


### PR DESCRIPTION
If the lobby is enabled in the room returns the lobby xmpp jid when trying to creat an outgoing call. UI can use this to auto-allow joining in the room.