### PR TITLE
fix: Fixes NPE when stats are slow to init.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -694,14 +694,6 @@ public class SipGatewaySession
                     .getAccountPropertyString(
                         CallContext.MUC_DOMAIN_PREFIX_PROP, "conference"));
 
-                // we have the room information, lets add cs to incoming call
-                if (statsHandler == null)
-                {
-                    String sipCallIdentifier = this.getMucDisplayName();
-                    statsHandler = new StatsHandler(
-                        sipCall, sipCallIdentifier, DEFAULT_STATS_REMOTE_ID + "-" + sipCallIdentifier);
-                }
-
                 joinJvbConference(callContext);
             }
             else
@@ -992,6 +984,14 @@ public class SipGatewaySession
                     }
                 }
             });
+        }
+
+        // lets add cs to the call
+        if (statsHandler == null)
+        {
+            String sipCallIdentifier = this.getMucDisplayName();
+            statsHandler = new StatsHandler(
+                sipCall, sipCallIdentifier, DEFAULT_STATS_REMOTE_ID + "-" + sipCallIdentifier);
         }
     }
 
@@ -1702,7 +1702,7 @@ public class SipGatewaySession
      * FIXME: to be removed
      */
     class WaitForJvbRoomNameThread
-            extends Thread
+        extends Thread
     {
         private boolean cancel = false;
 


### PR DESCRIPTION
The first init of StatsHandler is slow and we see errors like:
2021-01-08 18:22:32.033 INFO: [3575] org.jitsi.jigasi.SipGateway.incomingCallReceived().216 [ctx=16101301520322057628062] Incoming call received...
2021-01-08 18:22:32.076 INFO: [3575] org.jitsi.jigasi.stats.StatsHandler.getStatsServiceWrapper().276 [ctx=16101301520322057628062] Jitsi-stats library initializing for account: Jabber:jigasi@
2021-01-08 18:22:33.087 WARNING: [3577] org.jitsi.jigasi.SipGatewaySession.run().1745 [ctx=16101301520322057628062] No JVB room name provided in INVITE header
2021-01-08 18:22:33.102 INFO: [3579] org.jitsi.jigasi.SipGatewaySession.handleCallState().1616 [ctx=16101301520322057628062] SIP call ended: CallPeerChangeEvent: type=CallPeerStatusChange oldV=net.java.sip.communicator.service.protocol.CallPeerState:Incoming Call newV=net.java.sip.communicator.service.protocol.CallPeerState:Failed for peer=xxxx (+xxxx) <xxxx@jigasi.>;status=Failed
2021-01-08 18:22:33.102 INFO: [3579] org.jitsi.jigasi.SipGatewaySession.sipCallEnded().647 [ctx=16101301520322057628062] Sip call ended: Call: id=1610130152030399364142 peers=0
2021-01-08 18:22:33.103 SEVERE: [3579] org.jitsi.jigasi.AbstractGateway.notifyCallEnded().121 [ctx=16101301520322057628062] Call resource not exists for session.
2021-01-08 18:22:33.103 INFO: [3579] org.jitsi.jigasi.SipGatewaySession.peerStateChanged().1682 null SIP peer state: Failed
2021-01-08 18:22:33.357 SEVERE: [3575] impl.protocol.sip.SipStackSharing.logApplicationException().1145 An error occurred while processing event of type: javax.sip.DialogTerminatedEvent
java.lang.NullPointerException
	at org.jitsi.jigasi.JvbConference.start(JvbConference.java:491)
	at org.jitsi.jigasi.SipGatewaySession.joinJvbConference(SipGatewaySession.java:400)
	at org.jitsi.jigasi.SipGatewaySession.onJoinJitsiMeetRequest(SipGatewaySession.java:705)
	at net.java.sip.communicator.impl.protocol.sip.OperationSetJitsiMeetToolsSipImpl.notifyJoinJitsiMeetRoom(OperationSetJitsiMeetToolsSipImpl.java:146)
	at net.java.sip.communicator.impl.protocol.sip.CallSipImpl.processInvite(CallSipImpl.java:588)
	at net.java.sip.communicator.impl.protocol.sip.OperationSetBasicTelephonySipImpl.processInvite(OperationSetBasicTelephonySipImpl.java:1103)
	at net.java.sip.communicator.impl.protocol.sip.OperationSetBasicTelephonySipImpl.processRequest(OperationSetBasicTelephonySipImpl.java:337)
	at net.java.sip.communicator.impl.protocol.sip.ProtocolProviderServiceSipImpl.processRequest(ProtocolProviderServiceSipImpl.java:1115)
	at net.java.sip.communicator.impl.protocol.sip.SipStackSharing.processRequest(SipStackSharing.java:732)
	at gov.nist.javax.sip.EventScanner.deliverRequestEvent(EventScanner.java:250)
	at gov.nist.javax.sip.EventScanner.deliverEvent(EventScanner.java:146)
	at gov.nist.javax.sip.SipProviderImpl.handleEvent(SipProviderImpl.java:185)
	at gov.nist.javax.sip.DialogFilter.processRequest(DialogFilter.java:1324)
	at gov.nist.javax.sip.stack.SIPServerTransactionImpl.processRequest(SIPServerTransactionImpl.java:811)
	at gov.nist.javax.sip.stack.UDPMessageChannel.processMessage(UDPMessageChannel.java:568)
	at gov.nist.javax.sip.stack.UDPMessageChannel.processIncomingDataPacket(UDPMessageChannel.java:514)
	at gov.nist.javax.sip.stack.UDPMessageChannel.run(UDPMessageChannel.java:319)
	at java.lang.Thread.run(Thread.java:748)

This moves the initialization earlier so we don't count it in waiting for the headers.