### PR TITLE
use language codes matching jitsi-meet interface config.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
@@ -139,11 +139,9 @@ public class GoogleCloudTranscriptionService
             "hi-IN",
             "th-TH",
             "ko-KR",
-            "cmn-Hant-TW",
-            "yue-Hant-HK",
+            "zh-TW",
             "ja-JP",
-            "cmn-Hans-HK",
-            "cmn-Hans-CN",
+            "zh",
         };
 
     /**


### PR DESCRIPTION
tested with google quick start sample codes for Chinese sentence and worked.
See https://cloud.google.com/speech-to-text/docs/languages