### PR TITLE
fix: Uses correct ssrc for announcement and ssrc rewriting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-48-g9378af1e</version>
+      <version>1.0-50-g3ea1229d</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -454,30 +454,6 @@ public class JvbConference
     }
 
     /**
-     * Returns local SSRC of media stream sent towards given <tt>peer</tt>.
-     * @param peer the peer to whom media is sent.
-     * @param mediaType type of media sent.
-     */
-    private String getPeerSSRCforMedia(CallPeer peer, MediaType mediaType)
-    {
-        if (!(peer instanceof MediaAwareCallPeer))
-            return null;
-
-        MediaAwareCallPeer peerMedia = (MediaAwareCallPeer) peer;
-
-        CallPeerMediaHandler mediaHandler
-            = peerMedia.getMediaHandler();
-        if (mediaHandler == null)
-            return null;
-
-        MediaStream stream = mediaHandler.getStream(mediaType);
-        if (stream == null)
-            return null;
-
-        return Long.toString(stream.getLocalSourceID());
-    }
-
-    /**
      * Start this JVB conference handler.
      */
     public synchronized void start()

--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -1095,15 +1095,13 @@ public class SipGatewaySession
         {
             MediaAwareCallPeer peerMedia = (MediaAwareCallPeer) peer;
 
-            CallPeerMediaHandler mediaHandler
-                = peerMedia.getMediaHandler();
+            CallPeerMediaHandler mediaHandler = peerMedia.getMediaHandler();
             if (mediaHandler != null)
             {
                 MediaStream stream = mediaHandler.getStream(MediaType.AUDIO);
                 if (stream != null)
                 {
-                    stream.setExternalTransformer(
-                        new SsrcRewriter(stream.getLocalSourceID()));
+                    stream.setExternalTransformer(new SsrcRewriter(stream.getLocalSourceID()));
                     return true;
                 }
             }


### PR DESCRIPTION
In case of jigasi we are announcing the ssrc that will be sent early in the jingle and we want to return the ssrc from the translator/rtpManager and that to be the only value (not the random from the AudioMediaStreamImpl or -1 from ).