### PR TITLE
feat: drop jigasi callers without web users

### DIFF
--- a/jigasi-home/sip-communicator.properties
+++ b/jigasi-home/sip-communicator.properties
@@ -164,6 +164,10 @@ org.jitsi.jigasi.xmpp.acc.IS_FILE_TRANSFER_DISABLED=true
 # org.jitsi.jigasi.xmpp.acc.PASS=SOME_PASS
 # org.jitsi.jigasi.xmpp.acc.ANONYMOUS_AUTH=false
 
+# If you want to disconnect jigasi calls automatically when all web users have
+# left, you can set the following property to false.
+# org.jitsi.jigasi.ALLOW_ONLY_JIGASIS_IN_ROOM=true
+
 # If you want to use the SIP user part of the incoming/outgoing call SIP URI
 # you can set the following property to true.
 # org.jitsi.jigasi.USE_SIP_USER_AS_XMPP_RESOURCE=true

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -148,8 +148,8 @@ public class JvbConference
      * The name of the property which enables dropping jigasi calls
      * without anyone on the web.
      */
-    public static final String P_NAME_DISALLOW_ONLY_JIGASI
-        = "org.jitsi.jigasi.DISALLOW_ONLY_JIGASI";
+    public static final String P_NAME_ALLOW_ONLY_JIGASIS_IN_ROOM
+        = "org.jitsi.jigasi.ALLOW_ONLY_JIGASIS_IN_ROOM";
 
     /**
      * The default bridge id to use.
@@ -228,7 +228,7 @@ public class JvbConference
     /**
      * Whether to auto stop when only jigasi are left in the room.
      */
-    private boolean disallowOnlyJigasi = false;
+    private boolean allowOnlyJigasiInRoom = false;
 
     /**
      * The XMPP account used for the call handled by this instance.
@@ -389,8 +389,8 @@ public class JvbConference
     {
         this.gatewaySession = gatewaySession;
         this.callContext = ctx;
-        this.disallowOnlyJigasi = JigasiBundleActivator.getConfigurationService()
-            .getBoolean(P_NAME_DISALLOW_ONLY_JIGASI, false);
+        this.allowOnlyJigasiInRoom = JigasiBundleActivator.getConfigurationService()
+            .getBoolean(P_NAME_ALLOW_ONLY_JIGASIS_IN_ROOM, true);
     }
 
     private Localpart getResourceIdentifier()
@@ -1250,7 +1250,7 @@ public class JvbConference
         // but otherwise we will check whether there are jigasi participants
         // and jigasi cannot moderate those from lobby, we need to end the conference by all jigasi
         // leaving it
-        if ((this.lobbyEnabled && !this.singleModeratorEnabled) || this.disallowOnlyJigasi)
+        if ((this.lobbyEnabled && !this.singleModeratorEnabled) || !this.allowOnlyJigasiInRoom)
         {
             boolean onlyJigasisInRoom = this.mucRoom.getMembers().stream().allMatch(m ->
                 m.getName().equals(getResourceIdentifier().toString()) // ignore if it is us
@@ -1259,7 +1259,7 @@ public class JvbConference
 
             if (onlyJigasisInRoom)
             {
-                if (this.disallowOnlyJigasi)
+                if (!this.allowOnlyJigasiInRoom)
                 {
                     logger.info(this.callContext + " Leaving room without web users and only jigasi participants!");
                     stop();

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -145,6 +145,13 @@ public class JvbConference
         = "org.jitsi.jigasi.NOTIFY_MAX_OCCUPANTS";
 
     /**
+     * The name of the property which enables dropping jigasi calls
+     * without anyone on the web.
+     */
+    public static final String P_NAME_DISALLOW_ONLY_JIGASI
+        = "org.jitsi.jigasi.DISALLOW_ONLY_JIGASI";
+
+    /**
      * The default bridge id to use.
      */
     public static final String DEFAULT_BRIDGE_ID = "jitsi";
@@ -217,6 +224,11 @@ public class JvbConference
      * instance.
      */
     private final AbstractGatewaySession gatewaySession;
+
+    /**
+     * Whether to auto stop when only jigasi are left in the room.
+     */
+    private boolean disallowOnlyJigasi = false;
 
     /**
      * The XMPP account used for the call handled by this instance.
@@ -377,6 +389,8 @@ public class JvbConference
     {
         this.gatewaySession = gatewaySession;
         this.callContext = ctx;
+        this.disallowOnlyJigasi = JigasiBundleActivator.getConfigurationService()
+            .getBoolean(P_NAME_DISALLOW_ONLY_JIGASI, false);
     }
 
     private Localpart getResourceIdentifier()
@@ -1236,7 +1250,7 @@ public class JvbConference
         // but otherwise we will check whether there are jigasi participants
         // and jigasi cannot moderate those from lobby, we need to end the conference by all jigasi
         // leaving it
-        if (this.lobbyEnabled && !this.singleModeratorEnabled)
+        if ((this.lobbyEnabled && !this.singleModeratorEnabled) || this.disallowOnlyJigasi)
         {
             boolean onlyJigasisInRoom = this.mucRoom.getMembers().stream().allMatch(m ->
                 m.getName().equals(getResourceIdentifier().toString()) // ignore if it is us
@@ -1245,6 +1259,13 @@ public class JvbConference
 
             if (onlyJigasisInRoom)
             {
+                if (this.disallowOnlyJigasi)
+                {
+                    logger.info(this.callContext + " Leaving room without web users and only jigasi participants!");
+                    stop();
+                    return;
+                }
+
                 // there are only jigasi participants in the room with lobby enabled
                 logger.info(this.callContext + " Leaving room with lobby enabled and only jigasi participants!");
 


### PR DESCRIPTION
I use jigasi in a special "mode" where after all web users have left, all jigasi calls need to be dropped automatically.

I'm proposing this change so that I don't have to build my own all the time but I'm not sure if it's acceptable by the jitsi community.