### PR TITLE
fix: Handles burst of answer/hangup tasks.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/util/Util.java
+++ b/src/main/java/org/jitsi/jigasi/util/Util.java
@@ -256,7 +256,7 @@ public class Util
         return new ThreadPoolExecutor(
             1, size,
             60L, TimeUnit.SECONDS, // time to wait before clearing threads
-            new SynchronousQueue<>(),
+            new LinkedBlockingQueue<>(),
             new CustomizableThreadFactory(name, true));
     }
 }


### PR DESCRIPTION
When there is a burst of answer/hangups (more than 20 at a time) we end up with:
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@1ed35d34 rejected from java.util.concurrent.ThreadPoolExecutor@41de9032[Running, pool size = 20, active threads = 20, queued tasks = 0, completed tasks = ...]
We change it to unbound queue for tasks, there cannot be unlimited answer/hangups. It is also used and for handling dial-in requests ... that is protected for bursts from the XMPP side.