### PR TITLE
fix: Skips ZRTTransformEngine when encryption is disabled.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-51-gd1f44f8e</version>
+      <version>1.0-52-g7305854f</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
ZRTTransformEngine is being initialized by default even when DEFAULT_ENCRYPTION=false is set for the account.