### PR TITLE
fix: Fixes callstats reporting on the sip leg of the call.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -396,6 +396,14 @@ public class SipGatewaySession
     {
         cancelWaitThread();
 
+        // let's add callstats to the call
+        if (statsHandler == null)
+        {
+            String sipCallIdentifier = this.getMucDisplayName();
+            statsHandler = new StatsHandler(
+                sipCall, sipCallIdentifier, DEFAULT_STATS_REMOTE_ID + "-" + sipCallIdentifier);
+        }
+
         jvbConference = new JvbConference(this, ctx);
 
         jvbConference.start();
@@ -987,14 +995,6 @@ public class SipGatewaySession
                     }
                 }
             });
-        }
-
-        // lets add cs to the call
-        if (statsHandler == null)
-        {
-            String sipCallIdentifier = this.getMucDisplayName();
-            statsHandler = new StatsHandler(
-                sipCall, sipCallIdentifier, DEFAULT_STATS_REMOTE_ID + "-" + sipCallIdentifier);
         }
     }
 


### PR DESCRIPTION
initStatsService was failing to find the correct callstats config as it was executed before we receive the sip headers via onJoinJitsiMeetRequest. We need to domain (domain_base) to be able to match and find the correct xmpp account and callstats settings.