### PR TITLE
fix: Fixes ssrc rewrite when creating outgoing calls.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -410,31 +410,29 @@ public class SipGatewaySession
         if (destination == null)
         {
             incomingCall.setConference(sipCall.getConference());
+        }
 
-            boolean useTranslator = incomingCall.getProtocolProvider()
-                .getAccountID().getAccountPropertyBoolean(
-                    ProtocolProviderFactory.USE_TRANSLATOR_IN_CONFERENCE,
-                    false);
-            CallPeer peer = incomingCall.getCallPeers().next();
-            // if useTranslator is enabled add a ssrc rewriter
-            if (useTranslator && !addSsrcRewriter(peer))
+        boolean useTranslator = incomingCall.getProtocolProvider().getAccountID()
+            .getAccountPropertyBoolean(ProtocolProviderFactory.USE_TRANSLATOR_IN_CONFERENCE, false);
+        CallPeer peer = incomingCall.getCallPeers().next();
+        // if useTranslator is enabled add a ssrc rewriter
+        if (useTranslator && !addSsrcRewriter(peer))
+        {
+            peer.addCallPeerListener(new CallPeerAdapter()
             {
-                peer.addCallPeerListener(new CallPeerAdapter()
+                @Override
+                public void peerStateChanged(CallPeerChangeEvent evt)
                 {
-                    @Override
-                    public void peerStateChanged(CallPeerChangeEvent evt)
-                    {
-                        CallPeer peer = evt.getSourceCallPeer();
-                        CallPeerState peerState = peer.getState();
+                    CallPeer peer = evt.getSourceCallPeer();
+                    CallPeerState peerState = peer.getState();
 
-                        if (CallPeerState.CONNECTED.equals(peerState))
-                        {
-                            peer.removeCallPeerListener(this);
-                            addSsrcRewriter(peer);
-                        }
+                    if (CallPeerState.CONNECTED.equals(peerState))
+                    {
+                        peer.removeCallPeerListener(this);
+                        addSsrcRewriter(peer);
                     }
-                });
-            }
+                }
+            });
         }
 
         Exception error = this.onConferenceCallStarted(incomingCall);


### PR DESCRIPTION
Without rewriting the ssrc jigasi pass through the one incoming from the sip provider and browsers doing ssrc validation will fail to play the audio (Safari, Firefox and chrome with unified plan) as we had announced another ssrc earlier when setting up the call.