### PR TITLE
Bump jitsi-stats.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-stats</artifactId>
-      <version>1.0-8-gb408c35</version>
+      <version>1.0-10-g14e178c</version>
     </dependency>
     <dependency>
       <!--


### PR DESCRIPTION
Notably, this transitively pulls in log4j 2.15.0.