### PR TITLE
chore: Remove the sentry and agafua-syslog runtime dependencies.

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -27,5 +27,5 @@ com.agafua.syslog.SyslogHandler.facility = local0
 com.agafua.syslog.SyslogHandler.port = 514
 com.agafua.syslog.SyslogHandler.hostname = localhost
 
-# Sentry (uncomment handler to use)
-io.sentry.jul.SentryHandler.level=WARNING
+# Sentry (also add the sentry handler to "handlers" to use)
+# io.sentry.jul.SentryHandler.level=WARNING

--- a/pom.xml
+++ b/pom.xml
@@ -198,19 +198,6 @@
       <artifactId>jitsi-lgpl-dependencies</artifactId>
       <version>1.1-20190327.160813-5</version>
     </dependency>
-    <!-- runtime -->
-    <dependency>
-      <groupId>rusv</groupId>
-      <artifactId>agafua-syslog</artifactId>
-      <version>0.4</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.sentry</groupId>
-      <artifactId>sentry</artifactId>
-      <version>1.7.30</version>
-      <scope>runtime</scope>
-    </dependency>
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
@@ -221,6 +208,7 @@
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
     </dependency>
+    <!-- runtime -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>


### PR DESCRIPTION
This is to stop shipping non-essential jars and reduce potential exposure to vulnerabilities. Setting up sentry requires setting an environment variable (and potentially more changes?), so it should be easy to adapt to also include the sentry jar in the classpath.

cc @saghul @sapkra
