### PR TITLE
Tenant header option

### DIFF
--- a/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
@@ -123,18 +123,6 @@ public abstract class AbstractGatewaySession
     }
 
     /**
-     * Returns the name of the chat room that holds current JVB conference or
-     * <tt>null</tt> we're not in any room.
-     *
-     * @return the name of the chat room that holds current JVB conference or
-     *         <tt>null</tt> we're not in any room.
-     */
-    public String getJvbRoomName()
-    {
-        return jvbConference != null ? jvbConference.getRoomName() : null;
-    }
-
-    /**
      * Returns the url of the conference or null if we're not in a meeting
      *
      * @return the url or null

--- a/src/main/java/org/jitsi/jigasi/AudioModeration.java
+++ b/src/main/java/org/jitsi/jigasi/AudioModeration.java
@@ -456,7 +456,8 @@ public class AudioModeration
     {
         // we are here in the RegisterThread, and it is safe to query and wait
         // Uses disco info to discover the AV moderation address.
-        if (this.callContext.getDomain() != null)
+        // we need to query the domain part extracted from room jid
+        if (this.callContext.getRoomJidDomain() != null)
         {
             try
             {
@@ -469,7 +470,7 @@ public class AudioModeration
                 }
 
                 DiscoverInfo info = ServiceDiscoveryManager.getInstanceFor(this.jvbConference.getConnection())
-                    .discoverInfo(JidCreate.domainBareFrom(this.callContext.getDomain()));
+                    .discoverInfo(JidCreate.domainBareFrom(this.callContext.getRoomJidDomain()));
 
                 DiscoverInfo.Identity avIdentity =
                     info.getIdentities().stream().

--- a/src/main/java/org/jitsi/jigasi/CallContext.java
+++ b/src/main/java/org/jitsi/jigasi/CallContext.java
@@ -17,7 +17,7 @@
  */
 package org.jitsi.jigasi;
 
-import org.jitsi.jigasi.util.*;
+import net.java.sip.communicator.util.*;
 import org.jitsi.utils.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
@@ -33,6 +33,20 @@ import java.util.*;
  */
 public class CallContext
 {
+    private final static Logger logger = Logger.getLogger(CallContext.class);
+
+    /**
+     * The name of the property that is used to define the MUC service address.
+     * There are cases when authentication is used the authenticated user is
+     * using domain auth.main.domain and the muc service is under
+     * conference.main.domain. Then when joining a room without specifying
+     * the full address we will try searching using disco info for muc service
+     * under the domain auth.main.domain which will fail.
+     * We will use this property to fix those cases by manually configuring
+     * the address.
+     */
+    private static final String P_NAME_MUC_SERVICE_ADDRESS = "org.jitsi.jigasi.MUC_SERVICE_ADDRESS";
+
     /**
      * The account property to search in configuration service for the custom
      * bosh URL pattern which will be used when xmpp provider joins a room.
@@ -55,7 +69,16 @@ public class CallContext
     /**
      * The room name of the MUC room that holds JVB conference call.
      */
-    private String roomName;
+    private EntityBareJid roomJid;
+
+    /**
+     * The domain extracted from the room jid, without the tenant part.
+     * e.g. if room jid is roomname@muc.tenant.domain.com or roomname@muc.domain.com then <tt>roomJidDomain</tt> will
+     * have the value of domain.com.
+     * In case of docker <tt>domain</tt> can be the domain name of the deployment (used to construct the bosh url),
+     * but the room jid can be roomname@muc.tenant.meet.jitsi or roomname@muc.meet.jitsi.
+     */
+    private String roomJidDomain;
 
     /**
      * Domain that this call instance is handling.
@@ -100,11 +123,11 @@ public class CallContext
     private String destination;
 
     /**
-     * Muc address prefix, default is 'conference'.
-     * Used when parsing subdomain out of the full
+     * Muc address prefixes, default is 'conference' and 'muc'.
+     * Used when parsing tenant out of the full
      * room name 'roomName@conference.subdomain.domain'.
      */
-    private String mucAddressPrefix;
+    private List<String> mucAddressPrefixes = Arrays.asList(new String[]{"conference", "muc"}) ;
 
     /**
      * A timestamp when this context was created, used to construct the
@@ -152,20 +175,36 @@ public class CallContext
 
     /**
      * The room name of the MUC room that holds JVB conference call.
-     * @return the room name.
+     * Can just room name or the jid (roomname@conference.tenant.domain.net).
+     *
+     * @return the room name or jid.
      */
-    public String getRoomName()
+    public EntityBareJid getRoomJid()
     {
-        return roomName;
+        return this.roomJid;
     }
 
     /**
      * Sets the room name.
+     * Can just room name or the jid (roomname@conference.tenant.domain.net).
      * @param roomName the room name to use.
      */
     public void setRoomName(String roomName)
+        throws XmppStringprepException
     {
-        this.roomName = roomName;
+        if (!roomName.contains("@"))
+        {
+            // we check for optional muc service
+            String mucService = JigasiBundleActivator.getConfigurationService()
+                .getString(P_NAME_MUC_SERVICE_ADDRESS, null);
+            if (mucService != null)
+            {
+                roomName = roomName + "@" + mucService;
+            }
+        }
+
+        this.roomJid = JidCreate.entityBareFrom(roomName);
+
         update();
     }
 
@@ -175,12 +214,7 @@ public class CallContext
      */
     public String getConferenceName()
     {
-        if (this.roomName.contains("@"))
-        {
-            return Util.extractCallIdFromResource(this.roomName);
-        }
-
-        return this.roomName;
+        return this.roomJid.getLocalpart().toString();
     }
 
     /**
@@ -206,7 +240,15 @@ public class CallContext
 
         this.domain = domain;
         update();
-        updateCallResource();
+    }
+
+    /**
+     * The domain from the room jid that this call instance is handling.
+     * @return domain extracted from the room jid.
+     */
+    public String getRoomJidDomain()
+    {
+        return this.roomJidDomain;
     }
 
     /**
@@ -217,7 +259,7 @@ public class CallContext
     public void setTenant(String tenant)
     {
         this.tenant = tenant;
-        updateCallResource();
+        update();
     }
 
     /**
@@ -299,7 +341,13 @@ public class CallContext
      */
     public void setMucAddressPrefix(String mucAddressPrefix)
     {
-        this.mucAddressPrefix = mucAddressPrefix;
+        if (mucAddressPrefix == null)
+        {
+            return;
+        }
+
+        this.mucAddressPrefixes = Arrays.asList(mucAddressPrefix.split(","));
+
         update();
     }
 
@@ -339,7 +387,7 @@ public class CallContext
      */
     void updateCallResource()
     {
-        if (this.domain != null)
+        if (this.roomJidDomain != null)
         {
             try
             {
@@ -352,7 +400,7 @@ public class CallContext
                     String.format("%8h", random).replace(' ', '0')
                     + "@"
                     + (this.tenant != null ? this.tenant + "." : "")
-                    + this.domain);
+                    + this.roomJidDomain);
             }
             catch (XmppStringprepException e)
             {
@@ -377,60 +425,72 @@ public class CallContext
      *
      * If room address is just the node (roomname without @.... part) than
      * we just replace {host} with domain and {subdomain} with ''.
-     *
-     * If bosh URL pattern is missing or we are missing domain, we do not update
-     * anything.
      */
     private void update()
     {
-        // boshURL or domain missing, do nothing
-        if (boshURL == null
-            || StringUtils.isNullOrEmpty(domain))
-        {
-            return;
-        }
-
-        // we have domain let's update it
-        boshURL = boshURL.replace("{host}", domain);
-
         String subdomain = "";
-        if (roomName != null && roomName.contains("@"))
-        {
-            String mucAddress = roomName.substring(roomName.indexOf("@") + 1);
-            String mucAddressPrefix = this.mucAddressPrefix != null ? this.mucAddressPrefix : "conference";
 
-            // checks whether the string starts and ends with expected strings
-            // and also checks the length of strings that we will extract are not
-            // longer than the actual length
-            if (mucAddress.startsWith(mucAddressPrefix) && mucAddress.endsWith(domain))
-            {
-                // mucAddress not matching settings and passed domain, so skipping
-                if (mucAddressPrefix.length() + domain.length() + 2 < mucAddress.length())
+        if (this.getRoomJid() != null)
+        {
+
+            String mucAddress = this.getRoomJid().getDomain().toString();
+
+            // checks whether the string starts and ends with any of the expected strings
+            mucAddressPrefixes.forEach(prefix -> {
+                if (mucAddress.startsWith(prefix))
                 {
-                    // the pattern expects no / between host and subdomain, so we add it
-                    // extracting prefix + suffix plus two dots
-                    subdomain =mucAddress.substring(
-                        mucAddressPrefix.length() + 1,
-                        mucAddress.length() - domain.length() - 1);
-                    this.tenant = subdomain;
-                    subdomain = "/" + subdomain;
+                    String strippedMucAddress =  mucAddress.substring(prefix.length() + 1);
+
+                    if (this.tenant != null && strippedMucAddress.startsWith(this.tenant))
+                    {
+                        this.roomJidDomain = strippedMucAddress.substring(this.tenant.length() + 1);
+                    }
+                    // if it ends with the domain and the length indicates there is a tenant extract it
+                    else if (this.domain != null && strippedMucAddress.endsWith(this.domain)
+                        && strippedMucAddress.length() > this.domain.length() + 1)
+                    {
+                        this.roomJidDomain = this.domain;
+                        this.tenant = strippedMucAddress.substring(0, this.domain.length() - 1);
+                    }
+                    else
+                    {
+                        // not tenant
+                        this.roomJidDomain = strippedMucAddress;
+                    }
                 }
-            }
+            });
 
-            // update subdomain only when roomName is provided
-            // otherwise subdomain will be empty and we will loose the template,
-            // before we have a chance to check for subdomain in the
-            // target room name
-            boshURL = boshURL.replace("{subdomain}", subdomain);
-        }
-
-        if (this.authToken != null)
-        {
-            if (!boshURL.contains("&token="))
+            if (this.tenant != null)
             {
-                boshURL = boshURL + "&token=" + this.authToken;
+                subdomain = "/" + this.tenant;
+            }
+
+            if (this.roomJidDomain == null)
+            {
+                logger.warn("No roomJidDomain extracted from roomJid:" + this.getRoomJid() + ", tenant:" + this.tenant);
+                this.roomJidDomain = this.domain;
+            }
+
+            // if boshURL or domain missing, do nothing
+            if (boshURL != null && !StringUtils.isNullOrEmpty(domain))
+            {
+                // we have domain let's update it
+                boshURL = boshURL.replace("{host}", domain);
+
+                // update subdomain only when roomName is provided
+                // otherwise subdomain will be empty and we will loose the template,
+                // before we have a chance to check for subdomain in the
+                // target room name
+                boshURL = boshURL.replace("{subdomain}", subdomain);
             }
         }
+
+        if (this.authToken != null && boshURL != null && !boshURL.contains("&token="))
+        {
+            boshURL = boshURL + "&token=" + this.authToken;
+        }
+
+        this.updateCallResource();
     }
 
     /**
@@ -450,7 +510,7 @@ public class CallContext
     public String getMeetingUrl()
     {
         String url = getBoshURL();
-        String room = getRoomName();
+        String room = getConferenceName();
 
         if (url == null || room == null)
         {
@@ -458,7 +518,6 @@ public class CallContext
         }
 
         url = url.substring(0, url.indexOf("/http-bind"));
-        room = room.substring(0, room.indexOf("@"));
 
         return url + "/" + room;
     }

--- a/src/main/java/org/jitsi/jigasi/CallContext.java
+++ b/src/main/java/org/jitsi/jigasi/CallContext.java
@@ -63,18 +63,13 @@ public class CallContext
     private String domain;
 
     /**
-     * Sub-domain that this instance is handling.
-     * This property is optional.
+     * The tenant that this instance is handling.
      *
      * In case of deployments where multiple domains are managed, the value is
      * subtracted from the full conference room name
-     * 'roomName@conference.subdomain.domain'.
-     *
-     * Also used in deployments where we use jigasi as xmpp component
-     * and the value is the one that is passed as command line parameter
-     * '--subdomain'.
+     * 'roomName@conference.tenant.domain'.
      */
-    private String subDomain;
+    private String tenant;
 
     /**
      * Optional password required to enter MUC room.
@@ -215,23 +210,23 @@ public class CallContext
     }
 
     /**
-     * Sets the sub domain to use when creating a call resource or to be used
+     * Sets the tenant to use when creating a call resource or to be used
      * when updating bosh url.
-     * @param subDomain the subdomain to use.
+     * @param tenant the tenant to use.
      */
-    public void setSubDomain(String subDomain)
+    public void setTenant(String tenant)
     {
-        this.subDomain = subDomain;
+        this.tenant = tenant;
         updateCallResource();
     }
 
     /**
-     * Returns sub domain that this call instance is handling.
-     * @return sub domain that this call instance is handling.
+     * Returns tenant that this call instance is handling.
+     * @return tenant that this call instance is handling.
      */
-    public String getSubDomain()
+    public String getTenant()
     {
-        return subDomain;
+        return tenant;
     }
 
     /**
@@ -250,14 +245,6 @@ public class CallContext
     public void setRoomPassword(String roomPassword)
     {
         this.roomPassword = roomPassword;
-    }
-
-    /**
-     * Auth token to enter MUC room, optional.
-     * @return the token or null.
-     */
-    public String getAuthToken() {
-        return authToken;
     }
 
     /**
@@ -364,7 +351,7 @@ public class CallContext
                 this.callResource = JidCreate.entityBareFrom(
                     String.format("%8h", random).replace(' ', '0')
                     + "@"
-                    + (this.subDomain != null ? this.subDomain + "." : "")
+                    + (this.tenant != null ? this.tenant + "." : "")
                     + this.domain);
             }
             catch (XmppStringprepException e)
@@ -410,26 +397,22 @@ public class CallContext
         if (roomName != null && roomName.contains("@"))
         {
             String mucAddress = roomName.substring(roomName.indexOf("@") + 1);
-            String mucAddressPrefix = this.mucAddressPrefix != null ?
-                this.mucAddressPrefix : "conference";
+            String mucAddressPrefix = this.mucAddressPrefix != null ? this.mucAddressPrefix : "conference";
 
             // checks whether the string starts and ends with expected strings
             // and also checks the length of strings that we will extract are not
             // longer than the actual length
-            if (mucAddress.startsWith(mucAddressPrefix)
-                && mucAddress.endsWith(domain))
+            if (mucAddress.startsWith(mucAddressPrefix) && mucAddress.endsWith(domain))
             {
                 // mucAddress not matching settings and passed domain, so skipping
-                if (mucAddressPrefix.length() + domain.length() + 2
-                    < mucAddress.length())
+                if (mucAddressPrefix.length() + domain.length() + 2 < mucAddress.length())
                 {
                     // the pattern expects no / between host and subdomain, so we add it
                     // extracting prefix + suffix plus two dots
-                    subdomain =
-                        mucAddress.substring(
-                            mucAddressPrefix.length() + 1,
-                            mucAddress.length() - domain.length() - 1);
-                    this.subDomain = subdomain;
+                    subdomain =mucAddress.substring(
+                        mucAddressPrefix.length() + 1,
+                        mucAddress.length() - domain.length() - 1);
+                    this.tenant = subdomain;
                     subdomain = "/" + subdomain;
                 }
             }

--- a/src/main/java/org/jitsi/jigasi/CallContext.java
+++ b/src/main/java/org/jitsi/jigasi/CallContext.java
@@ -174,10 +174,9 @@ public class CallContext
     }
 
     /**
-     * The room name of the MUC room that holds JVB conference call.
-     * Can just room name or the jid (roomname@conference.tenant.domain.net).
+     * The room MUC bare jid (roomname@conference.tenant.domain.net or roomname@conference.domain.net).
      *
-     * @return the room name or jid.
+     * @return the room jid.
      */
     public EntityBareJid getRoomJid()
     {

--- a/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/SipGatewaySession.java
@@ -32,6 +32,7 @@ import org.jitsi.utils.concurrent.*;
 import org.jitsi.utils.*;
 import org.jivesoftware.smack.packet.*;
 import org.json.simple.*;
+import org.jxmpp.stringprep.*;
 
 import java.io.*;
 import java.text.*;
@@ -106,7 +107,7 @@ public class SipGatewaySession
     private final String domainBaseHeaderName;
 
     /**
-     * Defult value optional INVITE header which specifies the base domain
+     * Default value optional INVITE header which specifies the base domain
      * to be used to extract the subdomain from the roomname in order
      * to construct custom bosh URL to enter MUC room that is hosting
      * the Jitsi Meet conference.
@@ -119,6 +120,25 @@ public class SipGatewaySession
      */
     private static final String JITSI_MEET_DOMAIN_BASE_HEADER_PROPERTY
         = "JITSI_MEET_DOMAIN_BASE_HEADER_NAME";
+
+    /**
+     * The name of the header to search in the INVITE headers for domain tenant to be used.
+     * Tenant is used to construct custom bosh URL to enter MUC room that is hosting
+     * the Jitsi Meet conference.
+     */
+    private final String domainTenantHeaderName;
+
+    /**
+     * Default value optional INVITE header which specifies the domain tenant to be used.
+     */
+    public static final String JITSI_MEET_DOMAIN_TENANT_HEADER_DEFAULT
+        = "Jitsi-Conference-Domain-Tenant";
+
+    /**
+     * The account property to use to set custom header name for domain tenant.
+     */
+    private static final String JITSI_MEET_DOMAIN_TENANT_HEADER_PROPERTY
+        = "JITSI_MEET_DOMAIN_TENANT_HEADER_NAME";
 
     /**
      * Default status of our participant before we get any state from
@@ -316,6 +336,11 @@ public class SipGatewaySession
             .getAccountPropertyString(
                 JITSI_MEET_DOMAIN_BASE_HEADER_PROPERTY,
                 JITSI_MEET_DOMAIN_BASE_HEADER_DEFAULT);
+
+        domainTenantHeaderName = sipProvider.getAccountID()
+            .getAccountPropertyString(
+                JITSI_MEET_DOMAIN_TENANT_HEADER_PROPERTY,
+                JITSI_MEET_DOMAIN_TENANT_HEADER_DEFAULT);
 
         this.sipInfoJsonProtocol = new SipInfoJsonProtocol(jitsiMeetTools);
     }
@@ -537,33 +562,22 @@ public class SipGatewaySession
                 @Override
                 public void outgoingCallCreated(CallEvent callEvent)
                 {
-                    String roomName = getJvbRoomName();
+                    String roomName = getCallContext().getRoomJid().toString();
                     if (roomName != null)
                     {
                         Call call = callEvent.getSourceCall();
                         AtomicInteger headerCount = new AtomicInteger(0);
-                        call.setData(
-                            "EXTRA_HEADER_NAME." + headerCount.addAndGet(1),
-                            sipProvider.getAccountID()
-                                .getAccountPropertyString(
-                                    JITSI_MEET_ROOM_HEADER_PROPERTY,
-                                    "Jitsi-Conference-Room"));
-                        call.setData(
-                            "EXTRA_HEADER_VALUE." + headerCount.get(),
-                            roomName);
+                        call.setData("EXTRA_HEADER_NAME." + headerCount.addAndGet(1),
+                            sipProvider.getAccountID().getAccountPropertyString(
+                                JITSI_MEET_ROOM_HEADER_PROPERTY, "Jitsi-Conference-Room"));
+                        call.setData("EXTRA_HEADER_VALUE." + headerCount.get(), roomName);
 
                         // passes all extra headers to the outgoing call
                         callContext.getExtraHeaders().forEach(
                             (key, value) ->
                             {
-                                call.setData(
-                                    "EXTRA_HEADER_NAME."
-                                        + headerCount.addAndGet(1),
-                                    key);
-                                call.setData(
-                                    "EXTRA_HEADER_VALUE."
-                                        + headerCount.get(),
-                                    value);
+                                call.setData("EXTRA_HEADER_NAME." + headerCount.addAndGet(1), key);
+                                call.setData("EXTRA_HEADER_VALUE." + headerCount.get(), value);
                             });
                     }
 
@@ -679,25 +693,32 @@ public class SipGatewaySession
     public void onJoinJitsiMeetRequest(
         Call call, String room, Map<String, String> data)
     {
-        if (jvbConference == null && this.sipCall == call)
+        try
         {
-            if (room != null)
+            if (jvbConference == null && this.sipCall == call)
             {
-                callContext.setRoomName(room);
-                callContext.setRoomPassword(data.get(roomPassHeaderName));
-                callContext.setDomain(data.get(domainBaseHeaderName));
-                callContext.setAuthToken(data.get(authTokenHeaderName));
-                callContext.setMucAddressPrefix(sipProvider.getAccountID()
-                    .getAccountPropertyString(
-                        CallContext.MUC_DOMAIN_PREFIX_PROP, "conference"));
+                if (room != null)
+                {
+                    callContext.setRoomName(room);
+                    callContext.setRoomPassword(data.get(roomPassHeaderName));
+                    callContext.setDomain(data.get(domainBaseHeaderName));
+                    callContext.setTenant(data.get(domainTenantHeaderName));
+                    callContext.setAuthToken(data.get(authTokenHeaderName));
+                    callContext.setMucAddressPrefix(sipProvider.getAccountID()
+                        .getAccountPropertyString(CallContext.MUC_DOMAIN_PREFIX_PROP, null));
 
-                joinJvbConference(callContext);
+                    joinJvbConference(callContext);
+                }
+                else
+                {
+                    logger.warn("No JVB room name provided in INVITE header.");
+                    logger.info("Count of headers received:" + (data != null ? data.size() : 0));
+                }
             }
-            else
-            {
-                logger.warn("No JVB room name provided in INVITE header.");
-                logger.info("Count of headers received:" + (data != null ? data.size() : 0));
-            }
+        }
+        catch(XmppStringprepException e)
+        {
+            logger.error("Malformed JVB room name provided:" + room, e);
         }
     }
 
@@ -1509,8 +1530,7 @@ public class SipGatewaySession
                         return;
                     }
 
-                    if (getJvbRoomName() == null
-                           && !CallState.CALL_ENDED.equals(sipCall.getCallState()))
+                    if (getCallContext().getRoomJid() == null && !CallState.CALL_ENDED.equals(sipCall.getCallState()))
                     {
                         String defaultRoom
                             = JigasiBundleActivator.getConfigurationService()
@@ -1529,10 +1549,8 @@ public class SipGatewaySession
                         }
                         else
                         {
-                            logger.warn(
-                                SipGatewaySession.this.callContext
-                                + " No JVB room name provided in INVITE header"
-                            );
+                            logger.warn(SipGatewaySession.this.callContext
+                                + " No JVB room name provided in INVITE header");
 
                             hangUp(OperationSetBasicTelephony.HANGUP_REASON_BUSY_HERE, "No JVB room name provided");
                         }
@@ -1541,6 +1559,12 @@ public class SipGatewaySession
                 catch (InterruptedException e)
                 {
                     Thread.currentThread().interrupt();
+                }
+                catch(XmppStringprepException e)
+                {
+                    logger.error(SipGatewaySession.this.callContext + " Malformed default JVB room name.", e);
+
+                    hangUp(OperationSetBasicTelephony.HANGUP_REASON_BUSY_HERE, "No JVB room name provided");
                 }
             }
         }

--- a/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
@@ -137,7 +137,7 @@ public class TranscriptionGatewaySession
         // the room name, url and start listening
         transcriber.addTranscriptionListener(this);
         transcriber.addTranslationListener(this);
-        transcriber.setRoomName(getJvbRoomName());
+        transcriber.setRoomName(this.getCallContext().getRoomJid().toString());
         transcriber.setRoomUrl(getMeetingUrl());
 
         // We create a MediaWareCallConference whose MediaDevice

--- a/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
+++ b/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
@@ -338,22 +338,11 @@ public class StatsHandler
             return;
         }
 
-        EntityBareJid roomJid;
-        try
-        {
-            roomJid = JidCreate.entityBareFrom(callContext.getRoomName());
-        }
-        catch(XmppStringprepException e)
-        {
-            logger.warn("Not stating stats handler as provided roomName is not a jid:" + callContext.getRoomName(), e);
-            return;
-        }
-
         CallPeriodicRunnable cpr = StatsHandler.this.theStatsReporter = new CallPeriodicRunnable(
             call,
             this.statsService.interval,
             this.statsService.service,
-            roomJid,
+            this.callContext.getRoomJid(),
             this.statsService.conferenceIDPrefix,
             DEFAULT_JIGASI_ID + "-" + originID,
             remoteEndpointID);

--- a/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
+++ b/src/main/java/org/jitsi/jigasi/stats/StatsHandler.java
@@ -338,11 +338,19 @@ public class StatsHandler
             return;
         }
 
+        EntityBareJid roomJid = this.callContext.getRoomJid();
+
+        if (roomJid == null)
+        {
+            logger.warn(this.callContext + " Not stating stats handler as roomJid missing.");
+            return;
+        }
+
         CallPeriodicRunnable cpr = StatsHandler.this.theStatsReporter = new CallPeriodicRunnable(
             call,
             this.statsService.interval,
             this.statsService.service,
-            this.callContext.getRoomJid(),
+            roomJid,
             this.statsService.conferenceIDPrefix,
             DEFAULT_JIGASI_ID + "-" + originID,
             remoteEndpointID);

--- a/src/main/java/org/jitsi/jigasi/util/Util.java
+++ b/src/main/java/org/jitsi/jigasi/util/Util.java
@@ -84,19 +84,6 @@ public class Util
     }
 
     /**
-     * Call resource currently has the form of e23gr547@callcontro.server.net.
-     * This methods extract random call id part before '@' sign. In the example
-     * above it is 'e23gr547'.
-     * @param callResource the call resource/URI from which the call ID part
-     *                     will be extracted.
-     * @return extracted random call ID part from full call resource string.
-     */
-    public static String extractCallIdFromResource(String callResource)
-    {
-        return callResource.substring(0, callResource.indexOf("@"));
-    }
-
-    /**
      * Get the md5 hash of a string
      *
      * received from:

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControl.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControl.java
@@ -176,7 +176,14 @@ public class CallControl
                 if (ROOM_NAME_HEADER.equals(name))
                 {
                     roomName = value;
-                    ctx.setRoomName(roomName);
+                    try
+                    {
+                        ctx.setRoomName(roomName);
+                    }
+                    catch(XmppStringprepException e)
+                    {
+                        throw new RuntimeException("Malformed JvbRoomName header found " + roomName, e);
+                    }
                 }
                 else if (ROOM_PASSWORD_HEADER.equals(name))
                 {

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
@@ -773,7 +773,7 @@ public class CallControlMucActivator
             ctx.setBoshURL(acc.getAccountPropertyString(
                 CallContext.BOSH_URL_ACCOUNT_PROP));
             ctx.setMucAddressPrefix(acc.getAccountPropertyString(
-                CallContext.MUC_DOMAIN_PREFIX_PROP, "conference"));
+                CallContext.MUC_DOMAIN_PREFIX_PROP, null));
 
             return processIQ((T)iqRequest, ctx);
         }


### PR DESCRIPTION
Adds an option for new sip header to pass not only the domain, but and the tenant.
Adds muc prefix to cover cases when docker is used and the muc component address is `muc.meet.jitsi`.
Make sure we use the muc jid to construct any jid we will be using, for joining, for querying jicofo or hosts for av moderation or lobby.