### PR TITLE
feat: Adds option to override the bosh host that is used.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1571,6 +1571,8 @@ public class JvbConference
         {
             boshUrl = boshUrl.replace(
                 "{roomName}", callContext.getConferenceName());
+
+            logger.info(ctx + " Using bosh url:" + boshUrl);
             properties.put(JabberAccountID.BOSH_URL, boshUrl);
 
             if (ctx.hasAuthToken() &&  ctx.getAuthUserId() != null)


### PR DESCRIPTION
Normally the host for bosh is coming as the param domain_base, but this option helps to override it for specified domains.
org.jitsi.jigasi.BOSH_HOST_OVERRIDE=my.domain.com=other.domain.net,hop.domain.com=second.domain.net