### PR TITLE
fix: Blocking future answer calls if on answer is blocked.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/CallManager.java
+++ b/src/main/java/org/jitsi/jigasi/CallManager.java
@@ -38,15 +38,12 @@ public class CallManager
 {
     private final static Logger logger = Logger.getLogger(CallManager.class);
 
-    private static final int POOL_MAX_SIZE = 20;
-
     private static final String POOL_THREADS_PREFIX = "jigasi-callManager";
 
     /**
      * The thread pool to serve all call operations like answer and hangup.
-     * We initialize it with the 1 thread and can grow up to POOL_MAX_SIZE.
      */
-    private static ExecutorService threadPool = Util.createNewThreadPool(POOL_MAX_SIZE, POOL_THREADS_PREFIX);
+    private static ExecutorService threadPool = Util.createNewThreadPool(POOL_THREADS_PREFIX);
 
     private static boolean healthy = true;
 
@@ -692,6 +689,6 @@ public class CallManager
         if (!threadPool.isTerminated())
             throw new TimeoutException();
 
-        threadPool = Util.createNewThreadPool(POOL_MAX_SIZE, POOL_THREADS_PREFIX);
+        threadPool = Util.createNewThreadPool(POOL_THREADS_PREFIX);
     }
 }

--- a/src/main/java/org/jitsi/jigasi/util/Util.java
+++ b/src/main/java/org/jitsi/jigasi/util/Util.java
@@ -235,17 +235,16 @@ public class Util
     }
 
     /**
-     * Creates new thread pool.
-     * @param size the pool size.
+     * Creates new thread pool with one initial thread and can grow up.
      * @param name the threads name prefix.
      * @return the newly created pool.
      */
-    public static ExecutorService createNewThreadPool(int size, String name)
+    public static ExecutorService createNewThreadPool(String name)
     {
         return new ThreadPoolExecutor(
-            1, size,
+            1, 1000, // a pretty big thread pool size to avoid reaching capacity
             60L, TimeUnit.SECONDS, // time to wait before clearing threads
-            new LinkedBlockingQueue<>(),
+            new SynchronousQueue<>(),
             new CustomizableThreadFactory(name, true));
     }
 

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
@@ -77,7 +77,7 @@ public class CallControlMucActivator
     /**
      * The thread pool to serve all call control operations.
      */
-    private static ExecutorService threadPool = Util.createNewThreadPool(10, "jigasi-callcontrol");
+    private static ExecutorService threadPool = Util.createNewThreadPool("jigasi-callcontrol");
 
     /**
      * Starts muc control component. Finds all xmpp accounts and listen for


### PR DESCRIPTION
Making the call manager thread pull to grow from 1 to 1000. If we reach 1000 means there are a lot of blocked calls or there is an enormous burst of calls, in any way this jigasi will become unhealthy due to the large number of threads.
We have been seeing when calling answer to a call to get blocked that will prevent of spinning new threads to handle future answer calls and no media is being established.
Agent stays in running forever ¯\_(ツ)_/¯
"jigasi-callManagerpool-26-thread-1" #269 daemon prio=5 os_prio=0 tid=0x00007fad1c07e000 nid=0x2666 in Object.wait() [0x00007facf3abd000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at net.java.sip.communicator.impl.protocol.jabber.IceUdpTransportManager.wrapupConnectivityEstablishment(IceUdpTransportManager.java:1255)
	- locked <0x0000000704643dd0> (a java.lang.Object)
	at net.java.sip.communicator.impl.protocol.jabber.CallPeerJabberImpl.answer(CallPeerJabberImpl.java:194)
	- locked <0x0000000704628aa0> (a net.java.sip.communicator.impl.protocol.jabber.CallPeerJabberImpl)
	at net.java.sip.communicator.impl.protocol.jabber.OperationSetBasicTelephonyJabberImpl.answerCallPeer(OperationSetBasicTelephonyJabberImpl.java:807)
	at org.jitsi.jigasi.CallManager$AnswerCallThread.run(CallManager.java:359)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)