### PR TITLE
feat: Updates jitsi-xmpp extensions, fixes NPE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-33-g9f660fa</version>
+      <version>1.0-52-gd378a4e</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -774,7 +774,7 @@ public class JvbConference
                     .getString(LOCAL_REGION_PNAME);
                 if (StringUtils.isNotEmpty(region))
                 {
-                    RegionPacketExtension rpe = new RegionPacketExtension();
+                    JitsiParticipantRegionPacketExtension rpe = new JitsiParticipantRegionPacketExtension();
                     rpe.setRegionId(region);
 
                     ((ChatRoomJabberImpl)mucRoom)


### PR DESCRIPTION
2022-05-24 06:06:26.858 WARNING: [6379] org.jivesoftware.smack.util.PacketParserUtils.parsePresence: Failed to parse extension element in Presence stanza: PresenceBuilder(from='.....
java.lang.NullPointerException
        at org.jivesoftware.smack.packet.StanzaBuilder.addExtension(StanzaBuilder.java:160)
        at org.jivesoftware.smack.util.PacketParserUtils.parsePresence(PacketParserUtils.java:478)
        at org.jivesoftware.smack.util.PacketParserUtils.parseStanza(PacketParserUtils.java:115)
        at org.jivesoftware.smack.AbstractXMPPConnection.parseAndProcessStanza(AbstractXMPPConnection.java:1454)
        at org.jivesoftware.smack.bosh.XMPPBOSHConnection.access$1500(XMPPBOSHConnection.java:69)
        at org.jivesoftware.smack.bosh.XMPPBOSHConnection$BOSHPacketReader.responseReceived(XMPPBOSHConnection.java:520)
        at org.igniterealtime.jbosh.BOSHClient.fireResponseReceived(BOSHClient.java:1610)
        at org.igniterealtime.jbosh.BOSHClient.processExchange(BOSHClient.java:1145)
        at org.igniterealtime.jbosh.BOSHClient.processMessages(BOSHClient.java:999)
        at org.igniterealtime.jbosh.BOSHClient.access$300(BOSHClient.java:100)
        at org.igniterealtime.jbosh.BOSHClient$RequestProcessor.run(BOSHClient.java:1728)
        at java.base/java.lang.Thread.run(Thread.java:829)