### PR TITLE
feat: Updates smack.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.36</slf4j.version>
     <junit.version>5.8.2</junit.version>
-    <smack.version>4.4.6-20220526.182902-3</smack.version>
+    <smack.version>4.4.6-20220606.141457-4</smack.version>
     <jxmppVersion>1.0.3</jxmppVersion>
     <!-- Match jicoco's jetty version. -->
     <jicoco.version>1.1-107-gfb316f8</jicoco.version>

--- a/src/main/java/org/jitsi/jigasi/Main.java
+++ b/src/main/java/org/jitsi/jigasi/Main.java
@@ -262,6 +262,8 @@ public class Main
 
         ReflectionDebuggerFactory.setDebuggerClass(JulDebugger.class);
         SmackConfiguration.setDefaultReplyTimeout(15000);
+        // temporary workaround for stalled bosh connections that can block smack, will be removed in 4.5.
+        SmackConfiguration.TRUELY_ASYNC_SENDS = true;
 
         // Disable stream management as it could lead to unexpected behaviour,
         // because we do not account for that to happen.


### PR DESCRIPTION
Prevents bosh from blocking smack reactor which will result all smack communications to be blocked.
https://discourse.igniterealtime.org/t/bosh-connection-blocks-all-smackreactor-threads/91719