### PR TITLE
Configurable Google Speech to Text transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,11 @@ By default, the properties
 `org.jitsi.jigasi.transcription.ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION=false`
 and
 `org.jitsi.jigasi.transcription.ENABLE_GOOGLE_PROFANITY_FILTER=false`
+and
+`org.jitsi.jigasi.transcription.ENABLE_GOOGLE_INTERIM_RESULTS=false`
 in
 `jigasi-home/sip-communicator.properties`
+disable automatic punctuation, profanity filter and interim results for the transcription.
 To change this, simply set the desired property to `true` or `false`.
 
 Vosk configuration

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ sudo apt-get update && sudo apt-get install google-cloud-sdk google-cloud-sdk-ap
 gcloud init
 gcloud auth application-default login
 ```
+It is possible to enable or disable the functionality of Google Cloud Speech to Text.
+By default, the properties
+`org.jitsi.jigasi.transcription.ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION=false`
+in
+`jigasi-home/sip-communicator.properties`
+To change this, simply set the desired property to `true` or `false`.
 
 Vosk configuration
 ==================

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ gcloud auth application-default login
 It is possible to enable or disable the functionality of Google Cloud Speech to Text.
 By default, the properties
 `org.jitsi.jigasi.transcription.ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION=false`
+and
+`org.jitsi.jigasi.transcription.ENABLE_GOOGLE_PROFANITY_FILTER=false`
 in
 `jigasi-home/sip-communicator.properties`
 To change this, simply set the desired property to `true` or `false`.

--- a/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
@@ -192,6 +192,13 @@ public class GoogleCloudTranscriptionService
         = "org.jitsi.jigasi.transcription.ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION";
 
     /**
+     * Property name to determine whether the Google Speech API should censor
+     * profane words
+     */
+    private final static String P_NAME_ENABLE_GOOGLE_PROFANITY_FILTER
+        = "org.jitsi.jigasi.transcription.ENABLE_GOOGLE_PROFANITY_FILTER";
+
+    /**
      * The default value for the property USE_VIDEO_MODEL
      */
     private final static boolean DEFAULT_VALUE_USE_VIDEO_MODEL = false;
@@ -200,6 +207,11 @@ public class GoogleCloudTranscriptionService
      * The default value for the property ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION
      */
     private final static boolean DEFAULT_VALUE_ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION = false;
+
+    /**
+     * The default value for the property ENABLE_GOOGLE_PROFANITY_FILTER
+     */
+    private final static boolean DEFAULT_VALUE_ENABLE_GOOGLE_PROFANITY_FILTER = false;
 
     /**
      * Check whether the given string contains a supported language tag
@@ -240,6 +252,11 @@ public class GoogleCloudTranscriptionService
      * Whether to get automatic punctuation
      */
     private boolean enableAutomaticPunctuation;
+
+    /**
+     * Wheteher to enable profanity filter
+     */
+    private boolean enableProfanityFilter;
 
     /**
      * Creates the RecognitionConfig the Google service uses based
@@ -283,6 +300,9 @@ public class GoogleCloudTranscriptionService
         // set punctuation mode
         builder.setEnableAutomaticPunctuation(enableAutomaticPunctuation);
 
+        // set profanity filter
+        builder.setProfanityFilter(enableProfanityFilter);
+
         // set the Language tag
         String languageTag = request.getLocale().toLanguageTag();
         validateLanguageTag(languageTag);
@@ -307,6 +327,9 @@ public class GoogleCloudTranscriptionService
 
         enableAutomaticPunctuation = JigasiBundleActivator.getConfigurationService()
             .getBoolean(P_NAME_ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION, DEFAULT_VALUE_ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION);
+
+        enableProfanityFilter = JigasiBundleActivator.getConfigurationService()
+            .getBoolean(P_NAME_ENABLE_GOOGLE_PROFANITY_FILTER, DEFAULT_VALUE_ENABLE_GOOGLE_PROFANITY_FILTER);
     }
 
     /**

--- a/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
@@ -185,9 +185,21 @@ public class GoogleCloudTranscriptionService
         = "org.jitsi.jigasi.transcription.USE_VIDEO_MODEL";
 
     /**
+     * Property name to determine whether the Google Speech API should get
+     * automatic punctuation
+     */
+    private final static String P_NAME_ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION
+        = "org.jitsi.jigasi.transcription.ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION";
+
+    /**
      * The default value for the property USE_VIDEO_MODEL
      */
     private final static boolean DEFAULT_VALUE_USE_VIDEO_MODEL = false;
+
+    /**
+     * The default value for the property ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION
+     */
+    private final static boolean DEFAULT_VALUE_ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION = false;
 
     /**
      * Check whether the given string contains a supported language tag
@@ -223,6 +235,11 @@ public class GoogleCloudTranscriptionService
      * requests.
      */
     private boolean useVideoModel;
+
+    /**
+     * Whether to get automatic punctuation
+     */
+    private boolean enableAutomaticPunctuation;
 
     /**
      * Creates the RecognitionConfig the Google service uses based
@@ -263,6 +280,9 @@ public class GoogleCloudTranscriptionService
             builder.setModel("video");
         }
 
+        // set punctuation mode
+        builder.setEnableAutomaticPunctuation(enableAutomaticPunctuation);
+
         // set the Language tag
         String languageTag = request.getLocale().toLanguageTag();
         validateLanguageTag(languageTag);
@@ -284,6 +304,9 @@ public class GoogleCloudTranscriptionService
     {
         useVideoModel = JigasiBundleActivator.getConfigurationService()
             .getBoolean(P_NAME_USE_VIDEO_MODEL, DEFAULT_VALUE_USE_VIDEO_MODEL);
+
+        enableAutomaticPunctuation = JigasiBundleActivator.getConfigurationService()
+            .getBoolean(P_NAME_ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION, DEFAULT_VALUE_ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION);
     }
 
     /**


### PR DESCRIPTION
Options to enable punctuation and profanity filter to the results obtained when using Google Speech to Text for transcriptions.
Added option to enable the reception of interim results instead of only final results when using Google Speech to Text for transcriptions.
This options may be set in the sip-communicator.properties:
org.jitsi.jigasi.transcription.ENABLE_GOOGLE_AUTOMATIC_PUNCTUATION=false
org.jitsi.jigasi.transcription.ENABLE_GOOGLE_PROFANITY_FILTER=false
org.jitsi.jigasi.transcription.ENABLE_GOOGLE_INTERIM_RESULTS=false