### PR TITLE
feat: Set features as early as possible to avoid updating presence.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
-    <jitsi-desktop.version>2.14.8008466e1</jitsi-desktop.version>
+    <jitsi-desktop.version>2.14.c7330c51f</jitsi-desktop.version>
     <jitsi-desktop.groupId>org.jitsi.desktop</jitsi-desktop.groupId>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.36</slf4j.version>

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -361,6 +361,11 @@ public class JvbConference
     private final List<String> jigasiChatRoomMembers = Collections.synchronizedList(new ArrayList<>());
 
     /**
+     * The features for the current xmpp provider we will use later adding to the room presence we send.
+     */
+    private ExtensionElement features = null;
+
+    /**
      * Creates new instance of <tt>JvbConference</tt>
      * @param gatewaySession the <tt>AbstractGatewaySession</tt> that will be
      *                       using this <tt>JvbConference</tt>.
@@ -611,6 +616,9 @@ public class JvbConference
 
         this.xmppProvider = xmppProvider;
 
+        // Advertise gateway features before joining and if possible before connecting
+        this.features = addSupportedFeatures(xmppProvider.getOperationSet(OperationSetJitsiMeetToolsJabber.class));
+
         xmppProvider.addRegistrationStateChangeListener(this);
 
         this.telephony
@@ -726,10 +734,6 @@ public class JvbConference
 
     public void joinConferenceRoom()
     {
-        // Advertise gateway feature before joining
-        ExtensionElement features
-            = addSupportedFeatures(xmppProvider.getOperationSet(OperationSetJitsiMeetToolsJabber.class));
-
         OperationSetMultiUserChat muc = xmppProvider.getOperationSet(OperationSetMultiUserChat.class);
         muc.addPresenceListener(this);
 
@@ -810,7 +814,7 @@ public class JvbConference
                     ((ChatRoomJabberImpl)mucRoom).addPresencePacketExtensions(initiator);
                 }
 
-                ((ChatRoomJabberImpl)mucRoom).addPresencePacketExtensions(features);
+                ((ChatRoomJabberImpl)mucRoom).addPresencePacketExtensions(this.features);
             }
             else
             {


### PR DESCRIPTION
We have seen missing audio-mute support in jicofo as it doesn't update disco info after presence changes the advertised capabilities hash.