### PR TITLE
fix: source language equals target language no translation needed

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
@@ -343,7 +343,9 @@ public class Transcriber
                     String language
                         = translationLanguageExtension.getTranslationLanguage();
 
-                    this.updateParticipantTargetLanguage(identifier, language);
+                    if(!participant.getSourceLanguage().equals(language)) {
+                        this.updateParticipantTargetLanguage(identifier, language);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
When the source is equal with the target language we don't need to translate