### PR TITLE
fix: repeated strings in VOSK transcription results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,4 @@ dist
 jigasi-home/
 jigasi.iml
 
-target/
-out/
-src/main/resources/META-INF/
-
-.DS_Store
+target

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,8 @@ dist
 jigasi-home/
 jigasi.iml
 
-target
+target/
+out/
+src/main/resources/META-INF/
+
+.DS_Store

--- a/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
@@ -220,7 +220,7 @@ public class VoskTranscriptionService
                 result = obj.getString("text");
             }
 
-            if (!result.isEmpty() && !result.equals(lastResult))
+            if (!result.isEmpty() && (!partial || !result.equals(lastResult)))
             {
                 lastResult = result;
                 for (TranscriptionListener l : listeners)

--- a/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
@@ -175,6 +175,8 @@ public class VoskTranscriptionService
          */
         private final List<TranscriptionListener> listeners = new ArrayList<>();
 
+        private UUID uuid = UUID.randomUUID();
+
         VoskWebsocketStreamingSession(String debugName)
             throws Exception
         {
@@ -213,6 +215,7 @@ public class VoskTranscriptionService
                 partial = false;
                 result = obj.getString("text");
             }
+
             if (!result.isEmpty() && !result.equals(lastResult))
             {
                 lastResult = result;
@@ -220,12 +223,17 @@ public class VoskTranscriptionService
                 {
                     l.notify(new TranscriptionResult(
                             null,
-                            UUID.randomUUID(),
+                            this.uuid,
                             partial,
                             "C",
                             1.0,
                             new TranscriptionAlternative(result)));
                 }
+            }
+
+            if (!partial)
+            {
+                this.uuid = UUID.randomUUID();
             }
         }
 

--- a/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
@@ -175,6 +175,10 @@ public class VoskTranscriptionService
          */
         private final List<TranscriptionListener> listeners = new ArrayList<>();
 
+        /**
+         *  Latest assigned UUID to a transcription result.
+         *  A new one has to be generated whenever a definitive result is received.
+         */
         private UUID uuid = UUID.randomUUID();
 
         VoskWebsocketStreamingSession(String debugName)


### PR DESCRIPTION
This PR fixes repeated subtitles in VOSK transcription results.

The issue came from non-persistent UUIDs when sending the transcription results to Jitsi.

Creating a new UUID when the results are not `partial` fixes the issue.

Please let me know if I can add/edit anything to this PR.