### PR TITLE
chore: add files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ jigasi-home/
 jigasi.iml
 
 target
+out
+
+src/main/resources/META-INF/
+
+.DS_Store


### PR DESCRIPTION
This PR adds a few files to the `.gitignore`.

* `.DS_Store` are automatically generated files on MacOS that manages thumbnails, they shouldn't be added to the repository. Please let me know what you think of this change, as some people have it in their global `.gitignore`.
* `out` is the target folder when building artifacts with IntelliJ.

Please let me know if I can edit anything on this PR.

