### PR TITLE
fix: re-establish connection with transcription service if session is prematurely ended

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/Participant.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Participant.java
@@ -660,9 +660,15 @@ public class Participant
             {
                 session.sendRequest(request);
             }
+            else if (transcriber.getTranscriptionService().supportsStreamRecognition())
+            // re-establish prematurely ended streaming session
+            {
+                session = transcriber.getTranscriptionService()
+                        .initStreamingSession(this);
+                session.addTranscriptionListener(this);
+            }
             else
             // fallback if TranscriptionService does not support streams
-            // or session got ended prematurely
             {
                 // FIXME: 22/07/17 This just assumes given BUFFER_LENGTH
                 // is long enough to get decent audio length. Also does


### PR DESCRIPTION
This PR fixes the issue mentioned in the thread below:
https://community.jitsi.org/t/jigasi-randomly-starts-sending-raw-vosk-json-response-as-subtitles/117831

The problem came from lost websocket connection between jigasi and the VOSK transcription service.
Before the change, a participant whose audio should be transcribed switches to the single request mode when the session is prematurely ended. The PR allows Jigasi to check whether streaming is supported by the transcription service, and if it is the case, re-establish the streaming session.