### PR TITLE
LibreTranslate live translation service

### DIFF
--- a/jigasi-home/sip-communicator.properties
+++ b/jigasi-home/sip-communicator.properties
@@ -215,6 +215,10 @@ org.jitsi.jigasi.xmpp.acc.USE_DEFAULT_STUN_SERVER=false
 # org.jitsi.jigasi.transcription.customService=org.jitsi.jigasi.transcription.VoskTranscriptionService
 # org.jitsi.jigasi.transcription.vosk.websocket_url=ws://localhost:2700
 
+# LibreTranslate server
+# org.jitsi.jigasi.transcription.translationService=org.jitsi.jigasi.transcription.LibreTranslateTranslationService
+# org.jitsi.jigasi.transcription.libreTranslate.api_url=http://localhost:5000/translate
+
 # translation
 # org.jitsi.jigasi.transcription.ENABLE_TRANSLATION=false
 

--- a/src/main/java/org/jitsi/jigasi/transcription/LibreTranslateTranslationService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/LibreTranslateTranslationService.java
@@ -1,0 +1,112 @@
+package org.jitsi.jigasi.transcription;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.jitsi.jigasi.JigasiBundleActivator;
+import org.jitsi.utils.logging.Logger;
+import java.io.IOException;
+
+
+/**
+ * Implements a {@link TranslationService} which will use LibreTranslate API
+ * to translate the given text from one language to another.
+ * <p>
+ * <a href="https://github.com/LibreTranslate/LibreTranslate">LibreTranslate</a>
+ * for more information about LibreTranslate
+ *
+ * @author Pinglei He
+ */
+public class LibreTranslateTranslationService
+        implements TranslationService {
+
+    /*
+     * Class representing the json response body from LibreTranslate
+     * where response has status code 200.
+     * Used for json-to-POJO conversion with Gson.
+     */
+    class LibreTranslateResponse
+    {
+        private String translatedText;
+
+        public String getTranslatedText()
+        {
+            return translatedText;
+        }
+    }
+
+    /*
+     * The URL of the LibreTranslate API.
+     */
+    public final String API_URL
+            = "org.jitsi.jigasi.transcription.libreTranslate.api_url";
+
+    public final String DEFAULT_API_URL = "http://libretranslate:5000/translate";
+
+    private final String apiUrl;
+
+    private final Logger logger
+            = Logger.getLogger(LibreTranslateTranslationService.class);
+
+    public LibreTranslateTranslationService()
+    {
+        apiUrl = JigasiBundleActivator.getConfigurationService()
+                .getString(API_URL, DEFAULT_API_URL);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String translate(String sourceText,
+                            String sourceLang,
+                            String targetLang)
+    {
+        String payload = "{"
+                .concat("\"q\": \"" + sourceText + "\",")
+                .concat("\"source\": \"" + sourceLang.substring(0, 2) + "\",")
+                .concat("\"target\": \"" + targetLang.substring(0, 2) + "\",")
+                .concat("\"format\": \"text\",")
+                .concat("\"api_key\": \"\"")
+                .concat("}");
+
+        StringEntity entity = new StringEntity(payload,
+                ContentType.APPLICATION_JSON);
+
+        HttpResponse response;
+        try (CloseableHttpClient httpClient
+                     = HttpClientBuilder.create().build())
+        {
+            HttpPost request = new HttpPost(apiUrl);
+            request.setEntity(entity);
+            request.setHeader("Accept", "application/json");
+            request.setHeader("Content-type", "application/json");
+            response = httpClient.execute(request);
+            String jsonBody = EntityUtils.toString(response.getEntity());
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200)
+            {
+                logger.error("LibreTranslate responded with status code "
+                        + statusCode + ".");
+                logger.error(jsonBody);
+                return "";
+            }
+            Gson gson = new GsonBuilder().create();
+            LibreTranslateResponse translateResponse =
+                    gson.fromJson(jsonBody, LibreTranslateResponse.class);
+            return translateResponse.getTranslatedText();
+        }
+        catch (IOException e)
+        {
+            logger.error("Error during request to LibreTranslate service.");
+            logger.error(e.toString());
+            return "";
+        }
+    }
+}

--- a/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Transcriber.java
@@ -148,12 +148,14 @@ public class Transcriber
     private TranscribingAudioMixerMediaDevice mediaDevice
         = new TranscribingAudioMixerMediaDevice(this);
 
+    private static final String CUSTOM_TRANSLATION_SERVICE_PROP
+            = "org.jitsi.jigasi.transcription.translationService";
+
     /**
      * The TranslationManager and the TranslationService which will be used
      * for managing translations.
      */
-    private TranslationManager translationManager
-        = new TranslationManager(new GoogleCloudTranslationService());
+    private TranslationManager translationManager = null;
 
     /**
      * Every listener which will be notified when a new result comes in
@@ -223,6 +225,7 @@ public class Transcriber
         this.transcriptionService = service;
         addTranscriptionListener(this.transcript);
 
+        configureTranslationManager();
         if (isTranslationEnabled())
         {
             addTranscriptionListener(this.translationManager);
@@ -242,6 +245,45 @@ public class Transcriber
     public Transcriber(TranscriptionService service)
     {
         this(null, null, service);
+    }
+
+    /**
+     * Create the translationManager using the custom translation service
+     * configured by the user.
+     * Fallback to GoogleTranslationService if no custom translation service
+     * configuration.
+     */
+    public void configureTranslationManager()
+    {
+        String customTranslationServiceClass
+                = JigasiBundleActivator.getConfigurationService()
+                .getString(
+                        CUSTOM_TRANSLATION_SERVICE_PROP,
+                        null);
+
+        TranslationService translationService = null;
+        if (customTranslationServiceClass != null)
+        {
+            try
+            {
+                translationService = (TranslationService)Class
+                        .forName(customTranslationServiceClass)
+                        .getDeclaredConstructor()
+                        .newInstance();
+            }
+            catch(Exception e)
+            {
+                logger.error("Cannot instantiate custom translation service");
+            }
+        }
+
+        if (translationService == null)
+        {
+            translationService = new GoogleCloudTranslationService();
+        }
+
+        translationManager
+                = new TranslationManager(translationService);
     }
 
     /**


### PR DESCRIPTION
This is my initial attempt to integrate LibreTranslate into jigasi.

Currently, there are two transcription services supported in Jigasi: Google Cloud transcription service and Vosk transcription service, the ladder being open-source. However, only Google translate is supported for live translation of transcript/ subtitles. 

This pull request integrates the open source offline translation service [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) into jigasi, allowing users hosting Jitsi to use an alternative translation service to Google's translation API.

The LibreTranslate server supports more than 20 languages and 56 language-to-language models. It can be run offline (once the models are downloaded), and has [actively maintained container images](https://hub.docker.com/r/libretranslate/libretranslate) on Docker Hub.