### PR TITLE
feat: add VOSK routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ Then configure the transcription class with the following properly in `~/jigasi/
 org.jitsi.jigasi.transcription.customService=org.jitsi.jigasi.transcription.VoskTranscriptionService
 ```
 
+Finally, configure the websocket URL of the VOSK service in `~/jigasi/jigasi-home/sip-communicator.properties`:
+
+If you only have one VOSK service:
+
+```
+# org.jitsi.jigasi.transcription.vosk.websocket_url=ws://localhost:2700
+```
+
+If you have multiple VOSK services:
+```
+# org.jitsi.jigasi.transcription.vosk.websocket_url={"en": "ws://localhost:2700", "fr": "ws://localhost:2710"}
+```
+
 Transcription options
 =====================
 

--- a/jigasi-home/sip-communicator.properties
+++ b/jigasi-home/sip-communicator.properties
@@ -213,6 +213,7 @@ org.jitsi.jigasi.xmpp.acc.USE_DEFAULT_STUN_SERVER=false
 
 # Vosk server
 # org.jitsi.jigasi.transcription.customService=org.jitsi.jigasi.transcription.VoskTranscriptionService
+# org.jitsi.jigasi.transcription.vosk.websocket_url={"en": "ws://localhost:2700", "fr": "ws://localhost:2710"}
 # org.jitsi.jigasi.transcription.vosk.websocket_url=ws://localhost:2700
 
 # translation

--- a/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
@@ -212,6 +212,14 @@ public class GoogleCloudTranscriptionService
     }
 
     /**
+     * Language routing is handled by Google directly
+     */
+    public boolean supportsLanguageRouting()
+    {
+        return false;
+    }
+
+    /**
      * List of <tt>SpeechContext</tt>s to be inserted in
      * the <tt>RecognitionConfig</tt>. This is a list of phrases to be used as
      * a dictionary to assist the speech recognition.

--- a/src/main/java/org/jitsi/jigasi/transcription/Participant.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Participant.java
@@ -533,8 +533,7 @@ public class Participant
      */
     public void left()
     {
-        TranscriptionService.StreamingRecognitionSession
-                session = sessions.getOrDefault(getLanguageKey(), null);
+        TranscriptionService.StreamingRecognitionSession session = sessions.getOrDefault(getLanguageKey(), null);
         if (session != null)
         {
             session.end();
@@ -673,8 +672,7 @@ public class Participant
     {
         transcriber.executorService.execute(() ->
         {
-            TranscriptionService.StreamingRecognitionSession
-                    session = sessions.getOrDefault(getLanguageKey(), null);
+            TranscriptionService.StreamingRecognitionSession session = sessions.getOrDefault(getLanguageKey(), null);
             TranscriptionRequest request
                 = new TranscriptionRequest(audio,
                                            audioFormat,

--- a/src/main/java/org/jitsi/jigasi/transcription/Participant.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Participant.java
@@ -23,6 +23,7 @@ import org.jitsi.jigasi.util.Util;
 import org.jitsi.xmpp.extensions.jitsimeet.*;
 import org.jitsi.utils.logging.*;
 import org.jivesoftware.smack.packet.*;
+import org.objectweb.asm.Handle;
 
 import javax.media.format.*;
 import java.nio.*;
@@ -113,7 +114,7 @@ public class Participant
     /**
      * The streaming session which will constantly receive audio
      */
-    private TranscriptionService.StreamingRecognitionSession session;
+    private HashMap<String, TranscriptionService.StreamingRecognitionSession> sessions = new HashMap<>();
 
     /**
      * A buffer which is used to locally store audio before sending
@@ -341,6 +342,21 @@ public class Participant
     }
 
     /**
+     * Get the key to access the transcription session when language
+     * routing is supported
+     *
+     * @return the key of the Hashmap
+     */
+    public String getLanguageKey()
+    {
+        if (transcriber.getTranscriptionService().supportsLanguageRouting())
+        {
+            return this.getSourceLanguage();
+        }
+        return "global";
+    }
+
+    /**
      * Get the group id in the identity presence, if present
      *
      * @return the group id or null
@@ -493,6 +509,9 @@ public class Participant
      */
     void joined()
     {
+        TranscriptionService.StreamingRecognitionSession
+                session = sessions.getOrDefault(getLanguageKey(), null);
+
         if (session != null && !session.ended())
         {
             return; // no need to create new session
@@ -503,6 +522,7 @@ public class Participant
             session = transcriber.getTranscriptionService()
                 .initStreamingSession(this);
             session.addTranscriptionListener(this);
+            sessions.put(getLanguageKey(), session);
             isCompleted = false;
         }
     }
@@ -513,6 +533,8 @@ public class Participant
      */
     public void left()
     {
+        TranscriptionService.StreamingRecognitionSession
+                session = sessions.getOrDefault(getLanguageKey(), null);
         if (session != null)
         {
             session.end();
@@ -651,6 +673,8 @@ public class Participant
     {
         transcriber.executorService.execute(() ->
         {
+            TranscriptionService.StreamingRecognitionSession
+                    session = sessions.getOrDefault(getLanguageKey(), null);
             TranscriptionRequest request
                 = new TranscriptionRequest(audio,
                                            audioFormat,

--- a/src/main/java/org/jitsi/jigasi/transcription/TranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/TranscriptionService.java
@@ -65,6 +65,14 @@ public interface TranscriptionService
     boolean supportsStreamRecognition();
 
     /**
+     * Get whether this TranscriptionService supports language routing to
+     * redirect data to different websockets
+     *
+     * @return true when language routing is supported, false otherwise
+     */
+    boolean supportsLanguageRouting();
+
+    /**
      * Initialise a session which sends a continuous stream of audio to the
      * service to be transcribed
      *

--- a/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
@@ -23,8 +23,6 @@ import org.eclipse.jetty.websocket.client.*;
 import org.json.*;
 import org.jitsi.jigasi.*;
 import org.jitsi.utils.logging.*;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 
 import javax.media.format.*;
 import java.io.*;
@@ -73,13 +71,15 @@ public class VoskTranscriptionService
     /**
      * Assigns the websocketUrl to use to websocketUrl by reading websocketUrlConfig;
      */
-    private void generateWebsocketUrl(Participant participant) throws ParseException {
+    private void generateWebsocketUrl(Participant participant)
+        throws org.json.simple.parser.ParseException
+    {
         if (!supportsLanguageRouting())
         {
             websocketUrl = websocketUrlConfig;
         }
 
-        JSONParser jsonParser = new JSONParser();
+        org.json.simple.parser.JSONParser jsonParser = new org.json.simple.parser.JSONParser();
         Object obj = jsonParser.parse(websocketUrlConfig);
         JSONObject languageMap = (JSONObject) obj;
         websocketUrl = languageMap.optString(participant.getSourceLanguage());

--- a/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
@@ -88,7 +88,7 @@ public class VoskTranscriptionService
         org.json.simple.parser.JSONParser jsonParser = new org.json.simple.parser.JSONParser();
         Object obj = jsonParser.parse(websocketUrlConfig);
         JSONObject languageMap = (JSONObject) obj;
-        websocketUrl = languageMap.optString(participant.getSourceLanguage());
+        websocketUrl = languageMap.optString(participant.getSourceLanguage(), "en");
     }
 
     /**

--- a/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
@@ -55,7 +55,7 @@ public class VoskTranscriptionService
             = Logger.getLogger(VoskTranscriptionService.class);
 
     /**
-     * The URL of the websocket service speech-to-text service.
+     * The config key of the websocket to the speech-to-text service.
      */
     public final static String WEBSOCKET_URL
             = "org.jitsi.jigasi.transcription.vosk.websocket_url";
@@ -64,8 +64,14 @@ public class VoskTranscriptionService
 
     private final static String EOF_MESSAGE = "{\"eof\" : 1}";
 
+    /**
+     * The config value of the websocket to the speech-to-text service.
+     */
     private String websocketUrlConfig;
 
+    /**
+     * The URL of the websocket to the speech-to-text service.
+     */
     private String websocketUrl;
 
     /**


### PR DESCRIPTION
This PR implements language routing capabilities for the VOSK transcription service.

A VOSK model only allows one language, so each VOSK service can only transcribe one language. With language routing, we can assign a language to a websocket URL, which points to the correct VOSK container as shown in the image below:

![Jigasi-VOSK](https://user-images.githubusercontent.com/85990211/196706246-a84f0baa-0987-4d21-8bd0-a66f90779e1c.png)

Please let me know if I can provide any additional information/modifications.

