### PR TITLE
fix: missing return

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/VoskTranscriptionService.java
@@ -83,6 +83,7 @@ public class VoskTranscriptionService
         if (!supportsLanguageRouting())
         {
             websocketUrl = websocketUrlConfig;
+            return;
         }
 
         org.json.simple.parser.JSONParser jsonParser = new org.json.simple.parser.JSONParser();


### PR DESCRIPTION
This PR fixes a missing `return` statement.

Without it, the code below would be executed and the JSON serializer would try to parse a non-JSON string, causing an error.