### PR TITLE
feat: Implements a simple message to be set in call to check for serv…

### DIFF
--- a/src/main/java/org/jitsi/jigasi/sip/SipInfoJsonProtocol.java
+++ b/src/main/java/org/jitsi/jigasi/sip/SipInfoJsonProtocol.java
@@ -64,6 +64,7 @@ public class SipInfoJsonProtocol
         public static final int AV_MODERATION_ENABLED = 8;
         public static final int AV_MODERATION_APPROVED = 9;
         public static final int AV_MODERATION_DENIED = 10;
+        public static final int SIP_CALL_HEARTBEAT = 11;
     }
 
     private static class MESSAGE_HEADER
@@ -290,6 +291,20 @@ public class SipInfoJsonProtocol
         JSONObject obj = new JSONObject();
 
         obj.put(MESSAGE_HEADER.MESSAGE_TYPE, MESSAGE_TYPE.AV_MODERATION_DENIED);
+
+        return obj;
+    }
+
+    /**
+     * Creates new JSONObject for sip call heartbeat..
+     *
+     * @return JSONObject representing a message to be sent over SIP.
+     */
+    public static JSONObject createSIPCallHeartBeat()
+    {
+        JSONObject obj = new JSONObject();
+
+        obj.put(MESSAGE_HEADER.MESSAGE_TYPE, MESSAGE_TYPE.SIP_CALL_HEARTBEAT);
 
         return obj;
     }

--- a/src/main/java/org/jitsi/jigasi/stats/Statistics.java
+++ b/src/main/java/org/jitsi/jigasi/stats/Statistics.java
@@ -99,6 +99,11 @@ public class Statistics
     public static final String TOTAL_CALLS_JVB_NO_MEDIA = "total_calls_jvb_no_media";
 
     /**
+     * The name of the number of conferences for which we did not receive response to the sip heartbeat.
+     */
+    public static final String TOTAL_CALLS_NO_HEARTBEAT = "total_calls_no_heartbeat_response";
+
+    /**
      * The name of the property that holds the normalizing constant that is used to reduce the number of
      * current conferences to a stress level metric {@link #CONFERENCES_THRESHOLD}.
      */
@@ -173,6 +178,11 @@ public class Statistics
     private static AtomicLong totalCallsJvbNoMedia = new AtomicLong();
 
     /**
+     * Total number of calls dropped due to no response to sip heartbeat.
+     */
+    private static AtomicLong totalCallsWithNoHeartBeatResponse = new AtomicLong();
+
+    /**
      * Cumulative number of seconds of all conferences.
      */
     private static long cumulativeConferenceSeconds = 0;
@@ -242,6 +252,7 @@ public class Statistics
             totalCallsWithSipCalReconnected.get());
         stats.put(TOTAL_CALLS_WITH_JVB_MIGRATE, totalCallsWithJvbMigrate.get());
         stats.put(TOTAL_CALLS_JVB_NO_MEDIA, totalCallsJvbNoMedia.get());
+        stats.put(TOTAL_CALLS_NO_HEARTBEAT, totalCallsWithNoHeartBeatResponse.get());
 
         stats.put(SHUTDOWN_IN_PROGRESS,
             JigasiBundleActivator.isShutdownInProgress());
@@ -383,6 +394,14 @@ public class Statistics
     public static void incrementTotalCallsJvbNoMedia()
     {
         totalCallsJvbNoMedia.incrementAndGet();
+    }
+
+    /**
+     * Increment the value of total number of sip calls with no heartbeat.
+     */
+    public static void incrementTotalCallsWithNoSipHeartbeat()
+    {
+        totalCallsWithNoHeartBeatResponse.incrementAndGet();
     }
 
     /**


### PR DESCRIPTION
…er availability.

If there is a short network disruption and sip connection reconnects on TCP we may never receive the sip call BYE so we never cleanup and leak calls. This is a simple heartbeat like, sending a sip INFO message and expecting a reply, if two consecutive miss a response we drop the call, anyway it was dropped at server-side.