### PR TITLE
feat: Handles source-add with endpoint id.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1140,7 +1140,8 @@ public class JvbConference
                     {
                         try
                         {
-                            if (JidCreate.from(address).getResourceOrEmpty().equals(member.getName()))
+                            if (JidCreate.from(address).getResourceOrEmpty().equals(member.getName())
+                                || address.equals(member.getName()))
                             {
                                 peerMedia.removeConferenceMember(confMember);
                             }

--- a/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/TranscriptionGatewaySession.java
@@ -542,6 +542,7 @@ public class TranscriptionGatewaySession
     {
         // assume address is in the form
         // <room_name>@conference.<jitsi_meet_domain>/<some_unique_id>
+        // or just <some_unique_id>
         try
         {
             Jid jid = JidCreate.from(member.getAddress());
@@ -549,6 +550,10 @@ public class TranscriptionGatewaySession
             if (jid.hasResource())
             {
                 return jid.getResourceOrThrow().toString();
+            }
+            else
+            {
+                return jid.toString();
             }
         }
         catch (XmppStringprepException e)


### PR DESCRIPTION
In older format the whole jid is sent and we were extracting the resource, but the new one sends just the resource. The change broke transcriptions wher we need to match audio stream to participant.