### PR TITLE
feat: Use time-based uuid for transcription id.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
       <artifactId>websocket-jetty-client</artifactId>
       <version>${jetty.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
+      <version>4.1.0</version>
+    </dependency>
 
     <!-- org.jitsi -->
     <dependency>

--- a/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
@@ -355,7 +355,7 @@ public class GoogleCloudTranscriptionService
             resultConsumer.accept(
                     new TranscriptionResult(
                             null,
-                            UUID.randomUUID(),
+                            Generators.timeBasedReorderedGenerator().generate(),
                             false,
                             request.getLocale().toLanguageTag(),
                             0,
@@ -868,7 +868,7 @@ public class GoogleCloudTranscriptionService
          * A {@link UUID} which identifies the results (interim and final) of
          * the current session
          */
-        private UUID messageID;
+        private final UUID messageID;
 
         /**
          * Google provides multiple results per API response where the first one

--- a/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/GoogleCloudTranscriptionService.java
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jigasi.transcription;
 
+import com.fasterxml.uuid.*;
 import com.google.api.gax.rpc.*;
 import com.google.auth.oauth2.*;
 import com.google.cloud.speech.v1.*;
@@ -894,7 +895,7 @@ public class GoogleCloudTranscriptionService
             this.languageTag = languageTag;
             this.debugName = debugName;
 
-            messageID = UUID.randomUUID();
+            messageID = Generators.timeBasedReorderedGenerator().generate();
         }
 
         @Override


### PR DESCRIPTION
This allows sorting of the resulted messages based on the id, which is created when that message/phrase started.