### PR TITLE
fix: Fixes handling of destroying the room.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <assembly.skipAssembly>true</assembly.skipAssembly>
-    <jitsi-desktop.version>2.14.d9c09ec7e</jitsi-desktop.version>
+    <jitsi-desktop.version>2.14.4b03fc6a2</jitsi-desktop.version>
     <jitsi-desktop.groupId>org.jitsi.desktop</jitsi-desktop.groupId>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.36</slf4j.version>

--- a/src/main/java/org/jitsi/jigasi/lobby/Lobby.java
+++ b/src/main/java/org/jitsi/jigasi/lobby/Lobby.java
@@ -243,7 +243,7 @@ public class Lobby
 
     /**
      * Participant is kicked if rejected on join and this method handles the lobby rejection and lobby room destruction.
-     * Participant receives LOCAL_USER_LEFT if lobby is disabled.
+     * Participant receives LOCAL_USER_ROOM_DESTROYED if lobby is disabled.
      *
      * @param evt <tt>LocalUserChatRoomPresenceChangeEvent</tt> contains reason.
      */


### PR DESCRIPTION
Sometimes LOCAL_USER_LEFT is fired before room destroyed and sip call is not hangup waiting for xmpp to reconnect the jvb call. Race between stanza listeners, which will be the first to handle the presence stanza. After this change only destroy room event will be fired.