### PR TITLE
Timestamp improvements

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -1655,7 +1655,8 @@ public class JvbConference
                 }
             }
             else if ("org.jitsi.jigasi.xmpp.acc.USER_ID".equals(overridenProp)
-                && JigasiBundleActivator.getConfigurationService().getBoolean(overridePrefix + ".UNIQUE_USER_ID", false))
+                && JigasiBundleActivator.getConfigurationService().getBoolean(overridePrefix + ".UNIQUE_USER_ID",
+                    false))
             {
                 try
                 {

--- a/src/main/java/org/jitsi/jigasi/transcription/LocalJsonTranscriptHandler.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/LocalJsonTranscriptHandler.java
@@ -335,7 +335,7 @@ public class LocalJsonTranscriptHandler
         JSONObject jsonObject, TranscriptEvent e)
     {
         jsonObject.put(JSON_KEY_EVENT_EVENT_TYPE, e.getEvent().toString());
-        jsonObject.put(JSON_KEY_EVENT_TIMESTAMP, String.valueOf(e.getTimeStamp().toEpochMilli()));
+        jsonObject.put(JSON_KEY_EVENT_TIMESTAMP, e.getTimeStamp().toEpochMilli());
 
         JSONObject participantJson = new JSONObject();
 

--- a/src/main/java/org/jitsi/jigasi/transcription/RemotePublisherTranscriptionHandler.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/RemotePublisherTranscriptionHandler.java
@@ -99,7 +99,7 @@ public class RemotePublisherTranscriptionHandler
             object.put(JSON_KEY_EVENT_EVENT_TYPE,
                 event.getEvent().toString());
             object.put(JSON_KEY_EVENT_TIMESTAMP,
-                event.getTimeStamp().toString());
+                String.valueOf(event.getTimeStamp().toEpochMilli()));
         }
 
         for (String url : urls)

--- a/src/main/java/org/jitsi/jigasi/transcription/RemotePublisherTranscriptionHandler.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/RemotePublisherTranscriptionHandler.java
@@ -99,7 +99,7 @@ public class RemotePublisherTranscriptionHandler
             object.put(JSON_KEY_EVENT_EVENT_TYPE,
                 event.getEvent().toString());
             object.put(JSON_KEY_EVENT_TIMESTAMP,
-                String.valueOf(event.getTimeStamp().toEpochMilli()));
+                event.getTimeStamp().toEpochMilli());
         }
 
         for (String url : urls)

--- a/src/main/java/org/jitsi/jigasi/transcription/action/ActionServicesHandler.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/action/ActionServicesHandler.java
@@ -250,7 +250,7 @@ public class ActionServicesHandler
         object.put(LocalJsonTranscriptHandler.JSON_KEY_EVENT_EVENT_TYPE,
             event.getEvent().toString());
         object.put(LocalJsonTranscriptHandler.JSON_KEY_EVENT_TIMESTAMP,
-            String.valueOf(event.getTimeStamp().toEpochMilli()));
+            event.getTimeStamp().toEpochMilli());
 
         for (ActionHandler handler : actionSources.remove(roomName))
         {

--- a/src/main/java/org/jitsi/jigasi/transcription/action/ActionServicesHandler.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/action/ActionServicesHandler.java
@@ -250,7 +250,7 @@ public class ActionServicesHandler
         object.put(LocalJsonTranscriptHandler.JSON_KEY_EVENT_EVENT_TYPE,
             event.getEvent().toString());
         object.put(LocalJsonTranscriptHandler.JSON_KEY_EVENT_TIMESTAMP,
-            event.getTimeStamp().toString());
+            String.valueOf(event.getTimeStamp().toEpochMilli()));
 
         for (ActionHandler handler : actionSources.remove(roomName))
         {


### PR DESCRIPTION
In commit 89cb8987, "feat: Changes transcript msgs to have timestamp as milliseconds," there are two issues:

1. This didn't change the JSON output for all transcript messages. For instance, START and END event messages continued to have their timestamps encoded as an ISO-8601 string.
2. Arguably, most JSON parsers would expect epoch milliseconds encoded as a number rather than a string. 

This humble PR addresses both of those issues by ensuring all transcript JSON messages have their timestamps encoded as a JSON number (milliseconds since epoch). 