### PR TITLE
Avoid using XmlStringBuilder.toString()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-63-g441d6d5</version>
+      <version>1.0-78-g62d03d4</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
@@ -30,6 +30,7 @@ import org.jitsi.jigasi.util.*;
 import org.jitsi.utils.logging.Logger;
 import org.jitsi.xmpp.extensions.rayo.*;
 import org.jitsi.service.configuration.*;
+import org.jitsi.xmpp.util.*;
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.bosh.*;
 import org.jivesoftware.smack.iqrequest.*;
@@ -594,14 +595,16 @@ public class CallControlMucActivator
                             }
                             catch(SmackException.NotConnectedException | InterruptedException e)
                             {
-                                logger.error(ctx + " Cannot send reply for dialIQ:" + packet.toXML());
+                                logger.error(
+                                        ctx + " Cannot send reply for dialIQ:"
+                                                + XmlStringBuilderUtil.toStringOpt(packet));
                             }
                         }
                     });
             }
             catch (RejectedExecutionException e)
             {
-                logger.error(ctx + " Failed to handle incoming dialIQ:" + packet.toXML());
+                logger.error(ctx + " Failed to handle incoming dialIQ:" + XmlStringBuilderUtil.toStringOpt(packet));
 
                 return IQ.createErrorResponse(packet, StanzaError.getBuilder()
                     .setCondition(internal_server_error)
@@ -616,7 +619,7 @@ public class CallControlMucActivator
         {
             if (logger.isDebugEnabled())
             {
-                logger.debug(ctx + " Processing a RayoIq: " + packet.toXML());
+                logger.debug(ctx + " Processing a RayoIq: " + XmlStringBuilderUtil.toStringOpt(packet));
             }
 
             try


### PR DESCRIPTION
- chore: Update jitsi-xmpp-extensions.
- Avoid using XmlStringBuilder.toString.
