### PR TITLE
Update Java Debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,13 @@ Section: net
 Priority: extra
 Maintainer: Jitsi Team <dev@jitsi.org>
 Uploaders: Emil Ivov <emcho@jitsi.org>, Damian Minkov <damencho@jitsi.org>
-Build-Depends: debhelper, dh-systemd, openjdk-11-jdk, maven
+Build-Depends: debhelper, dh-systemd, java11-sdk, maven
 Standards-Version: 3.9.3
 Homepage: https://jitsi.org
 
 Package: jigasi
 Architecture: all
-Depends: ${misc:Depends}, default-jre-headless (>= 2:1.11), openssl, ruby-hocon
+Depends: ${misc:Depends}, java11-runtime-headless | java11-runtime, openssl, ruby-hocon
 Description: Jitsi Gateway for SIP
  Jitsi Meet is a WebRTC JavaScript application that uses Jitsi
  Videobridge to provide high quality, scalable video conferences.


### PR DESCRIPTION
Allows for running with Java 17 without any additional install.