### PR TITLE
fix: streaming session handling should account for dynamically changed transcription language

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/Participant.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/Participant.java
@@ -688,6 +688,7 @@ public class Participant
                 session = transcriber.getTranscriptionService()
                         .initStreamingSession(this);
                 session.addTranscriptionListener(this);
+                sessions.put(getLanguageKey(), session);
             }
             else
             // fallback if TranscriptionService does not support streams


### PR DESCRIPTION
We have been working on the ability to change the transcription language dynamically from the web UI: a participant modifying their local settings (Three dots -> Settings -> General -> Language) would be able to start speaking in another language and still get an accurate transcription.

We are testing this functionality with local Vosk instances and it's working fine, however we had to make a very small modification to the code: without this one line change, Jigasi starts creating a lot of new WebSockets and eventually exhausts all resources. This is because in `sendRequest()` we never keep track of newly created `TranscriptionService.StreamingRecognitionSession`s.

While we understand that changing transcription language dynamically is not something that is natively supported (yet) by Jigasi this small change is probably needed anyway to keep track of all the streaming sessions.