### PR TITLE
feat: Updates to latest libjitsi, opus 1.5.2.

### DIFF
--- a/debian/links
+++ b/debian/links
@@ -1,1 +1,0 @@
-/usr/share/jigasi/lib/libunix-0.5.1.so /usr/share/jigasi/lib/libunix-java.so

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.1-29-g00e62769</version>
+      <version>1.1-34-gb93ce2ee</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Drops a link that is no longer needed, the source file has been removed.
Also updates bouncycastle from 1.75 to 1.77.
