### PR TITLE
fix(reconfigure_xmpp): correctly provide password unencoded via REST

### DIFF
--- a/script/reconfigure_xmpp.sh
+++ b/script/reconfigure_xmpp.sh
@@ -31,7 +31,7 @@ for SERVER_ID in $CONFIG_SERVER_IDS; do
             | sed 's/=/":"/' \
             | sed 's/$/",/')"
     # build the json for the configuration call
-    echo "{$CONFIG_JSON\"id\":\"$SERVER_ID\"}" > /tmp/cc-muc.json
+    echo "{$CONFIG_JSON\"id\":\"$SERVER_ID\"}" | jq '. + {"PASSWORD": .PASSWORD|@base64d}' > /tmp/cc-muc.json
     if [ "$DRY_RUN" == "true" ]; then
         echo "Would Add MUC: $SERVER_ID"
         cat /tmp/cc-muc.json | grep -v 'PASSWORD' | jq


### PR DESCRIPTION
<!--
Hi, thanks for your contribution!
If you haven't already done so, could you please make sure you sign our CLA (https://jitsi.org/icla for individuals and https://jitsi.org/ccla for corporations)? We would, unfortunately, be unable to merge your patch unless we have that piece :(
-->
