### PR TITLE
fix(whisper): Fixes possible NPE.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/WhisperWebsocket.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/WhisperWebsocket.java
@@ -336,9 +336,20 @@ public class WhisperWebsocket
         return fullPayload;
     }
 
+    /**
+     * Disconnect a participant from the transcription service.
+     * @param participantId the participant to disconnect.
+     * @return <tt>true</tt> if the last participant has left and the session was closed.
+     * @throws IOException
+     */
     public boolean disconnectParticipant(String participantId)
         throws IOException
     {
+        if (this.wsSession == null)
+        {
+            return true;
+        }
+
         synchronized (this)
         {
             if (participants.containsKey(participantId))


### PR DESCRIPTION
Fixes:
2024-10-26 19:23:56.896 INFO: [254] WhisperWebsocket.disconnectParticipant#353: All participants have left, disconnecting from Whisper transcription server. 2024-10-26 19:23:56.897 SEVERE: [254] net.java.sip.communicator.util.UtilActivator.uncaughtException: An uncaught exception occurred in thread=Thread[jigasi-whisper-wspool-7-thread-2,5,main], and message was: Cannot invoke "org.eclipse.jetty.websocket.api.Session.getRemote()" because "this.wsSession" is null java.lang.NullPointerException: Cannot invoke "org.eclipse.jetty.websocket.api.Session.getRemote()" because "this.wsSession" is null
	at org.jitsi.jigasi.transcription.WhisperWebsocket.disconnectParticipant(WhisperWebsocket.java:354)
	at org.jitsi.jigasi.transcription.WhisperConnectionPool.endInternal(WhisperConnectionPool.java:99)
	at org.jitsi.jigasi.transcription.WhisperConnectionPool.lambda$end$0(WhisperConnectionPool.java:86)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)

<!--
Hi, thanks for your contribution!
If you haven't already done so, could you please make sure you sign our CLA (https://jitsi.org/icla for individuals and https://jitsi.org/ccla for corporations)? We would, unfortunately, be unable to merge your patch unless we have that piece :(
-->
