### PR TITLE
fix: clean up XMPP resource id

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -548,7 +548,7 @@ public class JvbConference
                 {
                     resourceIdentifier
                         = Localpart.from(
-                            resourceIdentBuilder.replace("[^A-Za-z0-9]", "-"));
+                            resourceIdentBuilder.replaceAll("[^A-Za-z0-9]", "-"));
                 }
                 catch (XmppStringprepException e)
                 {


### PR DESCRIPTION
Change replace to replaceAll
See https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#replaceAll(java.lang.String,java.lang.String)

CLA (https://jitsi.org/icla for individuals) already signed