### PR TITLE
fix: Sets default host for the rest plugin.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,5 +1,6 @@
 org.jitsi.jigasi {
   rest {
+    host = "127.0.0.1"
     port = 8788
     tls-port = 8743
   }


### PR DESCRIPTION
<!--
Hi, thanks for your contribution!
If you haven't already done so, could you please make sure you sign our CLA (https://jitsi.org/icla for individuals and https://jitsi.org/ccla for corporations)? We would, unfortunately, be unable to merge your patch unless we have that piece :(
-->
