### PR TITLE
fix: Fixes NPE on reconnect.

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -425,11 +425,6 @@ public class JvbConference
     private final ChatRoomPresenceListener presenceListener = new ChatRoomPresenceListener();
 
     /**
-     * The features for the current xmpp provider we will use later adding to the room presence we send.
-     */
-    private ExtensionElement features = null;
-
-    /**
      * Whether we are currently joining as a visitor.
      */
     private boolean isVisitor = false;
@@ -750,9 +745,6 @@ public class JvbConference
 
         this.xmppProvider = xmppProvider;
 
-        // Advertise gateway features before joining and if possible before connecting
-        this.features = addSupportedFeatures(xmppProvider.getOperationSet(OperationSetJitsiMeetToolsJabber.class));
-
         xmppProvider.addRegistrationStateChangeListener(this);
 
         this.telephony
@@ -1022,7 +1014,10 @@ public class JvbConference
                     chatRoom.addPresencePacketExtensions(initiator);
                 }
 
-                chatRoom.addPresencePacketExtensions(this.features);
+                // we want to add the features just before joining and after connecting
+                // to make sure EntityCapsManager.currentCapsVersion is properly initialized
+                chatRoom.addPresencePacketExtensions(
+                        addSupportedFeatures(xmppProvider.getOperationSet(OperationSetJitsiMeetToolsJabber.class)));
 
                 String statsId = JigasiBundleActivator.getConfigurationService().getString(STATS_ID_PNAME);
                 if (StringUtils.isNotEmpty(statsId))

--- a/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
+++ b/src/main/java/org/jitsi/jigasi/xmpp/CallControlMucActivator.java
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jigasi.xmpp;
 
+import static org.jitsi.jigasi.util.Util.*;
 import static org.jivesoftware.smack.packet.StanzaError.Condition.internal_server_error;
 
 import net.java.sip.communicator.impl.protocol.jabber.*;
@@ -34,6 +35,7 @@ import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.bosh.*;
 import org.jivesoftware.smack.iqrequest.*;
 import org.jivesoftware.smack.packet.*;
+import org.jivesoftware.smackx.disco.*;
 import org.jxmpp.jid.parts.*;
 import org.osgi.framework.*;
 
@@ -301,6 +303,9 @@ public class CallControlMucActivator
                 conn.registerIQRequestHandler(new HangUpIqHandler(pps));
 
                 connectionResource = conn.getUser().getResourceOrNull();
+
+                // to make sure EntityCapsManager.currentCapsVersion is properly initialized
+                ServiceDiscoveryManager.getInstanceFor(conn).addFeature(JIGASI_FEATURE_NAME);
             }
 
             OperationSetMultiUserChat muc = pps.getOperationSet(OperationSetMultiUserChat.class);


### PR DESCRIPTION
We saw that in the brewery connection, but it can happen and for the client connection to the room.

java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "key" is null
	at java.base/java.util.concurrent.ConcurrentHashMap.replaceNode(ConcurrentHashMap.java:1111)
	at java.base/java.util.concurrent.ConcurrentHashMap.remove(ConcurrentHashMap.java:1102)
	at org.jivesoftware.smackx.disco.ServiceDiscoveryManager.removeNodeInformationProvider(ServiceDiscoveryManager.java:387)
	at net.java.sip.communicator.impl.protocol.jabber.ScServiceDiscoveryManager.stop(ScServiceDiscoveryManager.java:680)
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.disconnectAndCleanConnection(ProtocolProviderServiceJabberImpl.java:1529)
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.unregisterInternal(ProtocolProviderServiceJabberImpl.java:1581)
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.unregisterInternal(ProtocolProviderServiceJabberImpl.java:1559)
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.unregister(ProtocolProviderServiceJabberImpl.java:1541)
	at net.java.sip.communicator.plugin.reconnectplugin.PPReconnectWrapper.unregister(PPReconnectWrapper.java:365)
	at net.java.sip.communicator.plugin.reconnectplugin.PPReconnectWrapper.reconnect(PPReconnectWrapper.java:348)
	at net.java.sip.communicator.plugin.reconnectplugin.PPReconnectWrapper.registrationStateChanged(PPReconnectWrapper.java:219)

Null is EntityCapsManager.currentCapsVersion and that is initialized on any CapabilitiesChanged, and EntityCapsManager always add a feature when enableEntityCaps is called. enableEntityCaps is called before adding the listener for CapabilitiesChanged and the add feature is executed in a blocking thread.

<!--
Hi, thanks for your contribution!
If you haven't already done so, could you please make sure you sign our CLA (https://jitsi.org/icla for individuals and https://jitsi.org/ccla for corporations)? We would, unfortunately, be unable to merge your patch unless we have that piece :(
-->
