### PR TITLE
feat: Updates libjitsi, small fix for dtls error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,12 +201,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-utils</artifactId>
-      <version>1.0-130-g1473517</version>
+      <version>1.0-147-g12d0b20</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.1-34-gb93ce2ee</version>
+      <version>1.1-46-gb4710e18</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Avoids IllegalArgumentException error.
We see from time to time: SEVERE: [10102681] RTPConnectorInputStream.runInReceiveThread#802: Failed to receive a packet:
                          java.lang.IllegalArgumentException: 'waitMillis' cannot be negative
                          	at org.bouncycastle.tls.DTLSTransport.receive(Unknown Source)
                          	at org.bouncycastle.tls.DTLSTransport.receive(Unknown Source)
                          	at org.jitsi.impl.neomedia.transform.dtls.DtlsPacketTransformer.reverseTransformDtls(DtlsPacketTransformer.java:901)

In BC 1.62 a check was added throwing the error if we pass -1, jvb passes 1 so we move to do the same.

<!--
Hi, thanks for your contribution!
If you haven't already done so, could you please make sure you sign our CLA (https://jitsi.org/icla for individuals and https://jitsi.org/ccla for corporations)? We would, unfortunately, be unable to merge your patch unless we have that piece :(
-->
