### PR TITLE
fix: remove leading and trailing dashes from the resource ident

### DIFF
--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -556,7 +556,8 @@ public class JvbConference
                 {
                     resourceIdentifier
                         = Localpart.from(
-                            resourceIdentBuilder.replaceAll("[^A-Za-z0-9]", "-"));
+                            resourceIdentBuilder.replaceAll("[^A-Za-z0-9]", "-")
+                                                .replaceAll("^-+|-+$", ""));
                 }
                 catch (XmppStringprepException e)
                 {


### PR DESCRIPTION
Sanitize the resource identifier by removing leading/trailing dashes. This prevents a fatal XmppStringprepException in Jicofo when it generates a Jingle session-initiate that includes a participant whose nickname starts with a hyphen, which is invalid for a JID.