### PR TITLE
use the same logic of jitsi-meet frontend for ISO codes handling

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/LibreTranslateTranslationService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/LibreTranslateTranslationService.java
@@ -73,6 +73,27 @@ public class LibreTranslateTranslationService
     }
 
     /**
+     * Utility function to extract the primary language code like:
+     * 'en-GB', 'en_GB', 'enGB', 'zh-CN', 'zh-TW'
+     *
+     * Behaves equivalent to the function " _getPrimaryLanguageCode"
+     * in jitsi-meet/blob/master/react/features/subtitles/middleware.ts
+     *
+     * @param language The language to use for translation or user requested.
+     * @return Primary language code
+    */
+    private static String getPrimaryLanguageCode(String language)
+    {
+        // can this actually happen? If yes, avoid NPE.
+        if (language == null)
+        {
+            return "auto";
+        }
+
+        return language.replaceAll("[-_A-Z].*", "");
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -80,8 +101,8 @@ public class LibreTranslateTranslationService
     {
         String payload = "{"
                 .concat("\"q\": \"" + sourceText + "\",")
-                .concat("\"source\": \"" + sourceLang.substring(0, 2) + "\",")
-                .concat("\"target\": \"" + targetLang.substring(0, 2) + "\",")
+                .concat("\"source\": \"" + getPrimaryLanguageCode(sourceLang) + "\",")
+                .concat("\"target\": \"" + getPrimaryLanguageCode(targetLang) + "\",")
                 .concat("\"format\": \"text\",")
                 .concat("\"api_key\": \"\"")
                 .concat("}");


### PR DESCRIPTION
When trying to use a libreatranslate compatible service for translation to/from Sorbian languages (ISO codes "hsb" and "dsb") I found that the implementation truncates these ISO codes to "hs" and "ds". while this can be work-arounded in a custom libretranslate instance, it is better to fix it here.

The fix is the same that is already in the web frontend https://github.com/jitsi/jitsi-meet/blob/d3249355016bc3b584e55a7bccde5c2164da6cea/react/features/subtitles/middleware.ts#L336 

I am not sure about the null ptr check. If it is guaranteed that the language code strings can never be null, this check is redundand. Please let me know so I can adjust the PR appropriately then.