### PR TITLE
docs(README): fix Skynet streaming Whisper websocket URL path

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ configuring the following properties in `/etc/jitsi/jigasi/sip-communicator.prop
 
 ```
 org.jitsi.jigasi.transcription.customService=org.jitsi.jigasi.transcription.WhisperTranscriptionService
-org.jitsi.jigasi.transcription.whisper.websocket_url=wss://<YOUR-DOMAIN>:<<PORT>>
+org.jitsi.jigasi.transcription.whisper.websocket_url=wss://<YOUR-DOMAIN>:<PORT>/streaming-whisper/ws
 ```
 
 If you also plan to enable the ASAP authentication, have a look at the 


### PR DESCRIPTION
### Fixes: #576 

### Summary
Fix the README example for Skynet + streaming Whisper by adding the required websocket endpoint path.

### Problem
The documented value:
`org.jitsi.jigasi.transcription.whisper.websocket_url=wss://<YOUR-DOMAIN>:<<PORT>>` is incomplete for Skynet streaming Whisper and leads to `403 Forbidden` errors.

### Fix
Updated README to use:
`org.jitsi.jigasi.transcription.whisper.websocket_url=wss://<YOUR-DOMAIN>:<PORT>/streaming-whisper/ws`

### Why this works
Skynet's streaming Whisper module expects websocket connections under /streaming-whisper/ws (with a meeting/connection ID appended), not at the host root.