### PR TITLE
Remove agafua-syslog dependency

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -1,6 +1,5 @@
 
 handlers= java.util.logging.ConsoleHandler
-#handlers= java.util.logging.ConsoleHandler, com.agafua.syslog.SyslogHandler
 #handlers= java.util.logging.ConsoleHandler, io.sentry.jul.SentryHandler
 
 java.util.logging.ConsoleHandler.level = ALL
@@ -20,12 +19,6 @@ net.java.sip.communicator.service.resources.AbstractResourcesService.level=SEVER
 org.jivesoftware.smack.roster.Roster.level=SEVERE
 
 #net.java.sip.communicator.service.protocol.level=ALL
-
-# Syslog (uncomment handler to use)
-com.agafua.syslog.SyslogHandler.transport = udp
-com.agafua.syslog.SyslogHandler.facility = local0
-com.agafua.syslog.SyslogHandler.port = 514
-com.agafua.syslog.SyslogHandler.hostname = localhost
 
 # Sentry (uncomment handler to use)
 io.sentry.jul.SentryHandler.level=WARNING

--- a/pom.xml
+++ b/pom.xml
@@ -245,12 +245,6 @@
     </dependency>
     <!-- runtime -->
     <dependency>
-      <groupId>rusv</groupId>
-      <artifactId>agafua-syslog</artifactId>
-      <version>0.4</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
       <version>5.3.0</version>


### PR DESCRIPTION
The syslog handler was already commented out in `logging.properties` — remove the unused dependency and the related dead config.