### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,9 +25,9 @@ jobs:
     name: Java ${{ matrix.java }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Set up Java ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
       with:
         distribution: temurin
         java-version: ${{ matrix.java }}
@@ -38,6 +38,6 @@ jobs:
 
     - name: Upload coverage report
       if: matrix.java == env.RELEASE_JAVA_VERSION
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4
       with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).