### PR TITLE
feat(transcription): add OCI Speech model domain config support (GENERIC/MEDICAL)

### DIFF
--- a/src/main/java/org/jitsi/jigasi/transcription/OracleTranscriptionService.java
+++ b/src/main/java/org/jitsi/jigasi/transcription/OracleTranscriptionService.java
@@ -92,6 +92,9 @@ public class OracleTranscriptionService
     public final static String OCI_INTERIM_THRESHOLD_MS
             = "org.jitsi.jigasi.transcription.oci.interimThresholdMs";
 
+    public final static String MODEL_DOMAIN
+            = "org.jitsi.jigasi.transcription.oci.modelDomain";
+
     public final static String DEFAULT_WEBSOCKET_URL = "ws://localhost:8000/ws";
 
     private BasicAuthenticationDetailsProvider authProvider;
@@ -104,6 +107,11 @@ public class OracleTranscriptionService
      * The config value of the websocket to the speech-to-text service.
      */
     private final String websocketUrlConfig;
+
+    /**
+     * The OCI model domain (GENERIC or MEDICAL). Null means the API default (GENERIC).
+     */
+    private final RealtimeParameters.ModelDomain modelDomain;
 
     /**
      * The final threshold in milliseconds
@@ -132,6 +140,22 @@ public class OracleTranscriptionService
         {
             logger.error("Missing OCI compartment ID");
             isConfiguredProperly = false;
+        }
+
+        String modelDomainConfig = JigasiBundleActivator.getConfigurationService()
+                .getString(MODEL_DOMAIN, null);
+        if (modelDomainConfig != null)
+        {
+            RealtimeParameters.ModelDomain parsed = RealtimeParameters.ModelDomain.create(modelDomainConfig);
+            if (parsed == null)
+            {
+                logger.warn("Unknown OCI modelDomain value '" + modelDomainConfig + "', using API default (GENERIC)");
+            }
+            modelDomain = parsed;
+        }
+        else
+        {
+            modelDomain = null;
         }
     }
 
@@ -247,11 +271,19 @@ public class OracleTranscriptionService
 
             languageCode = request.getLocale().toLanguageTag();
 
+            if (modelDomain == RealtimeParameters.ModelDomain.Medical
+                    && !request.getLocale().getLanguage().equals("en"))
+            {
+                logger.warn("OCI MEDICAL model domain only supports English (en-*). "
+                        + "Current language: " + languageCode + ". The request will likely fail.");
+            }
+
             final RealtimeParameters realtimeClientParameters = RealtimeParameters.builder()
                     .isAckEnabled(false)
                     .languageCode(languageCode)
                     .partialSilenceThresholdInMs(interimThresholdMs)
                     .finalSilenceThresholdInMs(finalThresholdMs)
+                    .modelDomain(modelDomain)
                     .build();
             try
             {


### PR DESCRIPTION
## Summary

Adds support for selecting the OCI Speech Realtime API **model domain** in `OracleTranscriptionService` via a new configuration property:

- New property: `org.jitsi.jigasi.transcription.oci.modelDomain`
- Accepted values: `GENERIC` (API default, unchanged behavior when unset) or `MEDICAL`
- The `MEDICAL` domain improves transcription accuracy on healthcare terminology
- Logs a warning when `MEDICAL` is configured with a non-English locale, since the OCI MEDICAL model only supports English (`en-*`)

## Configuration

Add to `sip-communicator.properties`:

```
# Optional — defaults to GENERIC when unset
org.jitsi.jigasi.transcription.oci.modelDomain=MEDICAL
```

## Evidence

### Successful connection with `modelDomain=MEDICAL` and `en-US`

```
INFO: Connecting to wss://realtime.aiservice.sa-saopaulo-1.oci.oraclecloud.com:443/ws/transcribe/stream
      ?isAckEnabled=false&partialSilenceThresholdInMs=200&finalSilenceThresholdInMs=300
      &languageCode=en-US&modelDomain=MEDICAL
INFO: Connected to: realtime.aiservice.sa-saopaulo-1.oci.oraclecloud.com/129.148.13.145:443
INFO: Connected to OCI Transcription Service
INFO: Received connect message: RealtimeMessageConnect(sessionId=55b80fbe-e7d9-4e8e-a764-9bfa1b8d668e)
```

### Expected failure with `modelDomain=MEDICAL` and `pt-BR` (OCI does not support MEDICAL for non-English)

```
INFO: Connecting to wss://realtime.aiservice.sa-saopaulo-1.oci.oraclecloud.com:443/ws/transcribe/stream
      ?isAckEnabled=false&partialSilenceThresholdInMs=200&finalSilenceThresholdInMs=300
      &languageCode=pt-BR&modelDomain=MEDICAL
SEVERE: Failed to connect to OCI Transcriber
  java.util.concurrent.ExecutionException: org.eclipse.jetty.websocket.api.exceptions.UpgradeException:
  Failed to upgrade to websocket: Unexpected HTTP Response Status Code: 400 Bad Request
```

The warning introduced in this PR surfaces this misconfiguration before the API rejects the connection.

## Test plan

- [x] Build passes (`mvn install -DskipTests`)
- [x] Checkstyle passes (`mvn checkstyle:check`)
- [x] Existing unit tests pass (`mvn test`)
- [x] Tested on a live OCI Speech endpoint with `modelDomain=MEDICAL` + `languageCode=en-US` — connection established and transcription received
- [x] Verified that `pt-BR` + `MEDICAL` produces a 400 from the API (expected — OCI limitation)
- [x] Omitting the property preserves existing behavior (no `modelDomain` query parameter sent)
