### PR TITLE
Update jitsi-utils, jicoco, jitsi-xmpp-extensions and ice4j; replace OrderedJsonObject with Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,26 @@
     <junit.version>5.8.2</junit.version>
     <smack.version>4.4.8-jitsi-4</smack.version>
     <jxmppVersion>1.0.3</jxmppVersion>
-    <jicoco.version>1.1-178-ga09ed33</jicoco.version>
+    <jicoco.version>1.1-179-g52cf6ef</jicoco.version>
+    <jitsi-utils.version>1.0-153-gd5c0102</jitsi-utils.version>
+    <jackson.version>2.21.5</jackson.version>
+    <kotlin.version>2.4.20</kotlin.version>
     <!-- Match jicoco's jetty version. -->
     <jetty.version>12.0.35</jetty.version>
     <oci-sdk.version>3.86.1</oci-sdk.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -204,9 +219,32 @@
       <version>${jitsi-desktop.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <!-- Runtime for the Kotlin-based jitsi libraries; declared so the version matches the compiler they were built
+           with rather than whichever transitive copy Maven finds first. -->
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1.1</version>
+      <exclusions>
+        <!-- json-simple 1.1.1 incorrectly lists junit as a compile dependency. -->
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-utils</artifactId>
-      <version>1.0-147-g12d0b20</version>
+      <version>${jitsi-utils.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -221,7 +259,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ice4j</artifactId>
-      <version>3.0-72-g824cd4b</version>
+      <version>3.2-19-gccf6bd6</version>
     </dependency>
     <dependency>
       <groupId>org.opentelecoms.sip</groupId>
@@ -356,7 +394,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-119-gc67bc81</version>
+      <version>1.0-124-g024f15d</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/jitsi/jigasi/AbstractGateway.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGateway.java
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jigasi;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import net.java.sip.communicator.service.protocol.*;
 
 import org.jitsi.utils.*;
@@ -117,14 +119,14 @@ public abstract class AbstractGateway<T extends AbstractGatewaySession>
     public abstract boolean isReady();
 
     /**
-     * @return an <tt>OrderedJsonObject</tt> instance that holds debug
+     * @return an <tt>ObjectNode</tt> instance that holds debug
      * information for this instance.
      */
-    public OrderedJsonObject getDebugState()
+    public ObjectNode getDebugState()
     {
-        OrderedJsonObject debugState = new OrderedJsonObject();
-        OrderedJsonObject sessionsJson = new OrderedJsonObject();
-        debugState.put("sessions", sessionsJson);
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
+        ObjectNode sessionsJson = JsonNodeFactory.instance.objectNode();
+        debugState.set("sessions", sessionsJson);
         synchronized (sessions)
         {
             sessions.forEach((callContext, session) -> {
@@ -133,7 +135,7 @@ public abstract class AbstractGateway<T extends AbstractGatewaySession>
                 {
                     displayName = Integer.toString(session.hashCode());
                 }
-                sessionsJson.put(displayName, session.getDebugState());
+                sessionsJson.set(displayName, session.getDebugState());
             });
         }
 

--- a/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
+++ b/src/main/java/org/jitsi/jigasi/AbstractGatewaySession.java
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jigasi;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.event.*;
 import org.jitsi.jigasi.lobby.*;
@@ -99,15 +101,15 @@ public abstract class AbstractGatewaySession
     }
 
     /**
-     * @return an <tt>OrderedJsonObject</tt> instance that holds debug
+     * @return an <tt>ObjectNode</tt> instance that holds debug
      * information for this instance.
      */
-    public OrderedJsonObject getDebugState()
+    public ObjectNode getDebugState()
     {
-        OrderedJsonObject debugState = new OrderedJsonObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
         if (jvbConference != null)
         {
-            debugState.put("jvbConference", jvbConference.getDebugState());
+            debugState.set("jvbConference", jvbConference.getDebugState());
         }
         return debugState;
     }

--- a/src/main/java/org/jitsi/jigasi/JvbConference.java
+++ b/src/main/java/org/jitsi/jigasi/JvbConference.java
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jigasi;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opentelemetry.api.trace.Span;
 import net.java.sip.communicator.impl.protocol.jabber.*;
 import net.java.sip.communicator.service.protocol.*;
@@ -1604,12 +1606,12 @@ public class JvbConference
     }
 
     /**
-     * @return an <tt>OrderedJsonObject</tt> instance that holds debug
+     * @return an <tt>ObjectNode</tt> instance that holds debug
      * information for this instance.
      */
-    public OrderedJsonObject getDebugState()
+    public ObjectNode getDebugState()
     {
-        OrderedJsonObject debugState = new OrderedJsonObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
         String meetingUrl = getMeetingUrl();
         if (StringUtils.isNotEmpty(meetingUrl))
         {

--- a/src/main/java/org/jitsi/jigasi/rest/HandlerImpl.java
+++ b/src/main/java/org/jitsi/jigasi/rest/HandlerImpl.java
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jigasi.rest;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
@@ -292,17 +294,17 @@ public class HandlerImpl
             HttpServletResponse response)
         throws IOException
     {
-        OrderedJsonObject debugState = new OrderedJsonObject();
-        JSONObject gatewaysJson = new JSONObject();
-        debugState.put("gateways", gatewaysJson);
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
+        ObjectNode gatewaysJson = JsonNodeFactory.instance.objectNode();
+        debugState.set("gateways", gatewaysJson);
         List<AbstractGateway> gateways
             = JigasiBundleActivator.getAvailableGateways();
-        gateways.forEach(gw -> gatewaysJson.put(gw.hashCode(), gw.getDebugState()));
+        gateways.forEach(gw -> gatewaysJson.set(String.valueOf(gw.hashCode()), gw.getDebugState()));
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         PrintWriter out = response.getWriter();
-        out.print(debugState.toJSONString());
+        out.print(debugState.toString());
     }
 
     /**


### PR DESCRIPTION
Picks up the current releases of the Kotlin-based jitsi libraries, all built with Kotlin 2.4.20:

| Dependency | From | To |
|---|---|---|
| jitsi-utils | 1.0-147 | 1.0-153-gd5c0102 |
| jicoco | 1.1-178 | 1.1-179-g52cf6ef (brings jitsi-metaconfig 1.0-18) |
| jitsi-xmpp-extensions | 1.0-119 | 1.0-124-g024f15d |
| ice4j | 3.0-72 | 3.2-19-gccf6bd6 |

jitsi-utils 1.0-150 removed `OrderedJsonObject` when it moved from json-simple to Jackson, so the debug-state code (`AbstractGateway`, `AbstractGatewaySession`, `JvbConference`, the REST debug endpoint) now builds Jackson `ObjectNode`s instead. Output is unchanged.

Jackson is pinned to a single version (2.21.5) through the Jackson BOM. The classpath previously mixed databind 2.12 (via jjwt), core 2.18 (via Jersey) and module-kotlin 2.19 (via jicoco), and the new jitsi-utils brings 2.21. `kotlin-stdlib` is declared directly so the runtime matches the compiler the jitsi libraries were built with. json-simple is declared explicitly: it used to arrive only transitively via jitsi-utils, which no longer ships it. jigasi keeps using json-simple for now because the desktop client API it implements (`OperationSetJitsiMeetTools.sendJSON` / `onJSONReceived`) takes json-simple types; moving the rest of jigasi to Jackson is a separate follow-up.

On ice4j: jigasi has no direct ice4j usage; it is on the classpath for jitsi-protocol-jabber, whose 2.14 modules were compiled against ice4j 3.2-8. The old 3.0-72 pin was therefore a downgrade relative to what those modules expect; 3.2-19 moves the runtime ahead of it. A bytecode check of every reference from the desktop modules and libjitsi into jitsi-utils, ice4j and xmpp-extensions resolves against the new versions.

Clean `mvn verify` passes with all tests.